### PR TITLE
refactor: pricing plans and fix moderation page bug

### DIFF
--- a/apps/frontend/src/dashboard/Moderation.vue
+++ b/apps/frontend/src/dashboard/Moderation.vue
@@ -9,7 +9,7 @@ import { useUpdatingData } from '@/functions/useUpdatingData';
 import { api } from '@/plugins/api';
 import { selectedDashboardStore } from '@/stores/userStore';
 
-const settings = ref<ModerationSettingsDto[]>();
+const settings = ref<ModerationSettingsDto[]>([]);
 const { t } = useI18n({
   useScope: 'global',
 });
@@ -34,8 +34,26 @@ async function save() {
     <div class="flow-root">
       <div class="btn btn-primary btn-sm float-left mb-5 md:w-auto rounded w-full">
         <button
-          class="bg-purple-600 duration-150 ease-in-out focus:outline-none focus:ring-0 font-medium hover:bg-purple-700 inline-block leading-tight px-6 py-2.5 rounded shadow text-white text-xs transition uppercase"
-          @click="save">
+          class="
+            bg-purple-600
+            duration-150
+            ease-in-out
+            focus:outline-none
+            focus:ring-0
+            font-medium
+            hover:bg-purple-700
+            inline-block
+            leading-tight
+            px-6
+            py-2.5
+            rounded
+            shadow
+            text-white text-xs
+            transition
+            uppercase
+          "
+          @click="save"
+        >
           {{ t('buttons.save') }}
         </button>
       </div>

--- a/apps/web/src/components/landing/FeatureCard.vue
+++ b/apps/web/src/components/landing/FeatureCard.vue
@@ -13,7 +13,7 @@
 <script lang="ts" setup>
 import { TswIcon } from '@tsuwari/ui-components';
 import { useWindowSize } from '@vueuse/core';
-import { ref } from 'vue';
+import { Ref, ref } from 'vue';
 
 import FeatureCardBgBlob from '@/components/landing/FeatureCardBgBlob.vue';
 import { useTranslation } from '@/services/locale';
@@ -27,20 +27,20 @@ defineProps<{
 const { t } = useTranslation<'landing'>();
 const { width: windowWidth } = useWindowSize();
 
-const card = ref<HTMLElement | null>(null);
+const card = ref(null) as Ref<HTMLElement | null>;
 </script>
 
 <style lang="postcss" scoped>
 .feature-card {
-  @apply min-md:p-7 py-8 min-md:rounded-[10px] inline-grid gap-y-6 relative z-10 overflow-hidden 
+  @apply min-md:p-7 py-8 min-md:rounded-[10px] flex flex-col h-full justify-center gap-y-6 relative z-10 overflow-hidden 
   min-md:border border-b border-black-25 min-md:border-black-20 min-md:bg-black-15 min-md:bg-opacity-30 
   min-md:hover:scale-[1.02] min-md:transition-transform min-md:duration-300;
 
-  & > h3 {
+  h3 {
     @apply min-md:text-[32px] text-[30px] font-medium leading-[120%];
   }
 
-  & > p {
+  p {
     @apply min-md:text-[17px] text-gray-70 leading-normal;
 
     max-height: 74px;

--- a/apps/web/src/components/landing/FeatureCardBgBlob.vue
+++ b/apps/web/src/components/landing/FeatureCardBgBlob.vue
@@ -9,7 +9,6 @@
 </template>
 
 <script lang="ts" setup>
-import type { MaybeElement } from '@vueuse/core';
 import { toRef } from 'vue';
 
 import PinkBlob from '@/assets/blob-pink.png';
@@ -17,7 +16,7 @@ import useFollowingBgImage from '@/utils/useFollowingBgImage.js';
 
 const props =
   defineProps<{
-    card: MaybeElement;
+    card: HTMLElement | null;
   }>();
 
 const cardRef = toRef(props, 'card');

--- a/apps/web/src/components/landing/PricingPlan.vue
+++ b/apps/web/src/components/landing/PricingPlan.vue
@@ -36,13 +36,13 @@
           class="inline-grid grid-flow-col justify-start"
         >
           <TswIcon
-            :name="featureTypeIcons[feature.status]"
+            :name="planGeneral[featureId].isAvaible === true ? 'Check' : 'Minus'"
             :height="22"
             :width="22"
             :class="`feature-icon mr-3 ${
               colorTheme === 'purple'
                 ? 'stroke-white-100'
-                : feature.status === 'accessible'
+                : planGeneral[featureId].isAvaible === true
                 ? 'stroke-purple-80'
                 : 'stroke-gray-70'
             }`"
@@ -58,13 +58,18 @@
 import { TswIcon } from '@tsuwari/ui-components';
 import { computed } from 'vue';
 
-import { featureTypeIcons } from '@/data/landing/pricingPlans.js';
-import type { PlanColorTheme, PricePlanLocale } from '@/data/landing/pricingPlans.js';
+import type {
+  PlanColorTheme,
+  PricingPlanLocale,
+  PricingPlans,
+  PlanGeneral,
+} from '@/data/landing/pricingPlans.js';
 import { useTranslation } from '@/services/locale';
 
 const props =
   defineProps<{
-    plan: PricePlanLocale;
+    plan: PricingPlanLocale<PricingPlans>;
+    planGeneral: PlanGeneral<PricingPlans>;
     colorTheme: PlanColorTheme;
   }>();
 

--- a/apps/web/src/components/landing/sections/FeaturesSection.vue
+++ b/apps/web/src/components/landing/sections/FeaturesSection.vue
@@ -1,6 +1,6 @@
 <template>
   <section class="py-24 max-md:py-18 min-md:px-10">
-    <div class="container max-w-[1200px]">
+    <div class="container max-w-[1080px]">
       <div class="flex w-full justify-between mb-14 max-md:mb-7 max-md:flex-col">
         <h2
           class="

--- a/apps/web/src/components/landing/sections/PricingSection.vue
+++ b/apps/web/src/components/landing/sections/PricingSection.vue
@@ -29,7 +29,11 @@
           "
         >
           <li v-for="(plan, planId) in pricePlans" :key="planId" class="flex w-full">
-            <PricingPlan :plan="plan" :colorTheme="planColorThemes[planId]" />
+            <PricingPlan
+              :plan="plan"
+              :colorTheme="planColorThemes[planId]"
+              :planGeneral="planFeaturesGeneral[planId]"
+            />
           </li>
         </ul>
       </div>
@@ -71,10 +75,10 @@ import CyanBlob from '@/assets/blob-cyan.png';
 import WavesSvg from '@/assets/Waves.svg';
 import ClientOnly from '@/components/ClientOnly.vue';
 import PricingPlan from '@/components/landing/PricingPlan.vue';
-import { planColorThemes, type PricePlansLocale } from '@/data/landing/pricingPlans.js';
+import { planColorThemes, planFeaturesGeneral } from '@/data/landing/pricingPlans.js';
 import { useTranslation } from '@/services/locale';
 
 const { t, tm } = useTranslation<'landing'>();
 
-const pricePlans = computed(() => tm('sections.pricing.plans') as PricePlansLocale);
+const pricePlans = computed(() => tm('sections.pricing.plans'));
 </script>

--- a/apps/web/src/data/landing/pricingPlans.ts
+++ b/apps/web/src/data/landing/pricingPlans.ts
@@ -1,36 +1,13 @@
-import type { IconName } from '@tsuwari/ui-components';
-
-export type FeatureType = 'accessible' | 'limited';
-
-interface PlanFeatures {
-  [PlanId.basic]: BasicPlanFeatures;
-  [PlanId.pro]: ProPlanFeatures;
-}
-
-export type PricePlanLocale = PricePlansLocale[keyof PricePlansLocale];
-
-export type PricePlansLocale = {
-  [P in PlanId]: {
-    name: string;
-    price: number;
-    features: {
-      [F in PlanFeatures[P]]: {
-        name: string;
-        status: FeatureType;
-      };
-    };
-  };
-};
-
-export type PlanColorTheme = 'purple' | 'gray';
-
-export type PlanColorThemes = { [K in PlanId]: PlanColorTheme };
-
-export enum PlanId {
+// List of pricing plans
+export enum PricingPlans {
   basic,
   pro,
 }
 
+/**
+ * Enums for plan features are created to index a unique key for each
+ * feature. We need it for mapping translations with right feature.
+ */
 export enum BasicPlanFeatures {
   first,
   second,
@@ -43,12 +20,64 @@ export enum ProPlanFeatures {
   last,
 }
 
-export const planColorThemes: PlanColorThemes = {
-  [PlanId.basic]: 'gray',
-  [PlanId.pro]: 'purple',
+// Mapping of plan enum with plan features
+interface PlanFeatures {
+  [PricingPlans.basic]: BasicPlanFeatures;
+  [PricingPlans.pro]: ProPlanFeatures;
+}
+
+type PlanFeature = { name: string; isAvaible: boolean };
+
+// General info it's information that will not change depends on translation
+export type PlanGeneral<Plan extends PricingPlans> = {
+  [Feature in PlanFeatures[Plan]]: Pick<PlanFeature, 'isAvaible'>;
 };
 
-export const featureTypeIcons: Record<FeatureType, IconName> = {
-  accessible: 'Check',
-  limited: 'Minus',
+type PlanFeaturesGeneral = {
+  [Plan in PricingPlans]: PlanGeneral<Plan>;
+};
+
+export const planFeaturesGeneral: PlanFeaturesGeneral = {
+  [PricingPlans.basic]: {
+    [BasicPlanFeatures.first]: {
+      isAvaible: true,
+    },
+    [BasicPlanFeatures.second]: {
+      isAvaible: true,
+    },
+    [BasicPlanFeatures.last]: {
+      isAvaible: false,
+    },
+  },
+  [PricingPlans.pro]: {
+    [ProPlanFeatures.first]: {
+      isAvaible: true,
+    },
+    [ProPlanFeatures.second]: {
+      isAvaible: true,
+    },
+    [ProPlanFeatures.last]: {
+      isAvaible: true,
+    },
+  },
+};
+
+// Represents a single plan type for translation
+export type PricingPlanLocale<Plan extends PricingPlans> = {
+  name: string;
+  price: number;
+  features: Record<PlanFeatures[Plan], Pick<PlanFeature, 'name'>>;
+};
+
+// Translate object of all plans.
+export type PricingPlansLocale = {
+  [Plan in PricingPlans]: PricingPlanLocale<Plan>;
+};
+
+// Every plan has own color theme
+export type PlanColorTheme = 'purple' | 'gray';
+
+export const planColorThemes: Record<PricingPlans, PlanColorTheme> = {
+  [PricingPlans.basic]: 'gray',
+  [PricingPlans.pro]: 'purple',
 };

--- a/apps/web/src/locales/landing/en.ts
+++ b/apps/web/src/locales/landing/en.ts
@@ -1,4 +1,4 @@
-import { BasicPlanFeatures, PlanId, ProPlanFeatures } from '@/data/landing/pricingPlans.js';
+import { BasicPlanFeatures, PricingPlans, ProPlanFeatures } from '@/data/landing/pricingPlans.js';
 import { LandingSection } from '@/data/landing/sections.js';
 import { TeamMemberId } from '@/data/landing/team.js';
 import type ILandingLocale from '@/locales/landing/interface.js';
@@ -61,39 +61,33 @@ const messages: ILandingLocale = {
       features: 'Features',
       perMonth: 'per month',
       plans: {
-        [PlanId.basic]: {
+        [PricingPlans.basic]: {
           name: 'Basic plan',
           price: 0,
           features: {
             [BasicPlanFeatures.first]: {
               name: 'Unlimited commands',
-              status: 'accessible',
             },
             [BasicPlanFeatures.second]: {
               name: 'Unlimited commands',
-              status: 'accessible',
             },
             [BasicPlanFeatures.last]: {
               name: 'Unlimited commands',
-              status: 'limited',
             },
           },
         },
-        [PlanId.pro]: {
+        [PricingPlans.pro]: {
           name: 'Pro plan',
           price: 10,
           features: {
             [ProPlanFeatures.first]: {
               name: 'Unlimited commands',
-              status: 'accessible',
             },
             [ProPlanFeatures.second]: {
               name: 'Unlimited commands',
-              status: 'accessible',
             },
             [ProPlanFeatures.last]: {
               name: 'Unlimited commands',
-              status: 'accessible',
             },
           },
         },

--- a/apps/web/src/locales/landing/interface.ts
+++ b/apps/web/src/locales/landing/interface.ts
@@ -1,5 +1,5 @@
 import type { BotFeature } from '@/data/landing/botFeatures.js';
-import type { PricePlansLocale } from '@/data/landing/pricingPlans.js';
+import type { PricingPlansLocale } from '@/data/landing/pricingPlans.js';
 import type { NavMenuLocale } from '@/data/landing/sections.js';
 import type { TeamMemberLocale } from '@/data/landing/team.js';
 
@@ -44,7 +44,7 @@ interface ILandingLocale {
       title: string;
       features: string;
       perMonth: string;
-      plans: PricePlansLocale;
+      plans: PricingPlansLocale;
     };
     subscribeForUpdates: {
       title: string;

--- a/apps/web/src/locales/landing/ru.ts
+++ b/apps/web/src/locales/landing/ru.ts
@@ -1,4 +1,4 @@
-import { BasicPlanFeatures, PlanId, ProPlanFeatures } from '@/data/landing/pricingPlans.js';
+import { BasicPlanFeatures, PricingPlans, ProPlanFeatures } from '@/data/landing/pricingPlans.js';
 import { LandingSection } from '@/data/landing/sections.js';
 import { TeamMemberId } from '@/data/landing/team.js';
 import type ILandingLocale from '@/locales/landing/interface.js';
@@ -63,39 +63,33 @@ const messages: ILandingLocale = {
       features: 'Функции',
       perMonth: 'в месяц',
       plans: {
-        [PlanId.basic]: {
+        [PricingPlans.basic]: {
           name: 'Базовый план',
           price: 0,
           features: {
             [BasicPlanFeatures.first]: {
               name: 'Unlimited commands',
-              status: 'accessible',
             },
             [BasicPlanFeatures.second]: {
               name: 'Unlimited commands',
-              status: 'accessible',
             },
             [BasicPlanFeatures.last]: {
               name: 'Unlimited commands',
-              status: 'limited',
             },
           },
         },
-        [PlanId.pro]: {
+        [PricingPlans.pro]: {
           name: 'Профессиональный план',
           price: 10,
           features: {
             [ProPlanFeatures.first]: {
               name: 'Unlimited commands',
-              status: 'accessible',
             },
             [ProPlanFeatures.second]: {
               name: 'Unlimited commands',
-              status: 'accessible',
             },
             [ProPlanFeatures.last]: {
               name: 'Unlimited commands',
-              status: 'accessible',
             },
           },
         },


### PR DESCRIPTION
## Пофиксил баг в дашборде на странице moderation. 
Пример ошибки в продакшне:

![image](https://user-images.githubusercontent.com/51422045/204547250-cd3ceb92-0716-467a-9226-cf19a9c7338c.png)

https://github.com/Satont/tsuwari/commit/c317caf45e806044be0f95412b19ec3d0f5f9c8c#diff-ca0059a7344cd2e1aba9aa16aa59d1f35b1d91ae2a708ec9bdddd506d96b10b6L12-R12

Не было установлено стартовое значение для setting ref. Было undefined, поставил пустой массив. 

Пофиксил высоту карточки features на лэндосе, баги c типами, отрефакторил планы и их переводы. Добавил туда немного комментариев.
