### PR TITLE
feat: add `twir_only` for `TwitchSearchChannels`

### DIFF
--- a/libs/api/messages/twitch/twitch.proto
+++ b/libs/api/messages/twitch/twitch.proto
@@ -25,6 +25,7 @@ message TwitchGetUsersResponse {
 
 message TwitchSearchChannelsRequest {
 	string query = 1;
+	bool twir_only = 2;
 }
 
 message Channel {


### PR DESCRIPTION
/cc @crashmax-dev 

Notifcations in admin-panel should use `unprotectedapiclient.TwitchSearchChannels` endpoint for searching targeting user.