### PR TITLE
chore(dev): use right redis image in development

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -27,10 +27,11 @@ services:
       - tsuwari-dev
 
   redis:
-    image: redis/redis-stack-server:latest
+    image: redis/redis-stack:latest
     restart: always
     ports:
       - '6385:6379'
+      - '8001:8001'
     volumes:
       - redis-data:/data
     networks:


### PR DESCRIPTION
It's will be nice to use RedisInsight(nice redis gui) during development. Dunno why but they say that it's not best way to use this in production, so let's it be in dev only.