### PR TITLE
feat: commands with expiration

### DIFF
--- a/apps/api-gql/schema/commands.graphqls
+++ b/apps/api-gql/schema/commands.graphqls
@@ -33,6 +33,9 @@ type Command {
 	requiredWatchTime: Int!
 	requiredMessages: Int!
 	requiredUsedChannelPoints: Int!
+	expiredIn: Int!
+	expired: Boolean!
+	expiresAt: Time
 	group: CommandGroup
 }
 type CommandResponse {
@@ -80,6 +83,7 @@ input CommandsCreateOpts {
 	requiredWatchTime: Int!
 	requiredMessages: Int!
 	requiredUsedChannelPoints: Int!
+	expiredIn: Int!
 	groupId: String @validate(constraint: "max=500,omitempty")
 }
 
@@ -103,6 +107,8 @@ input CommandsUpdateOpts {
 	requiredWatchTime: Int
 	requiredMessages: Int
 	requiredUsedChannelPoints: Int
+	expiredIn: Int
+	expired: Boolean
 	groupId: String @validate(constraint: "max=500,omitempty")
 }
 

--- a/apps/scheduler/app/app.go
+++ b/apps/scheduler/app/app.go
@@ -40,6 +40,7 @@ var App = fx.Module(
 		timers.NewCommandsAndRoles,
 		timers.NewBannedChannels,
 		timers.NewWatched,
+		timers.NewExpiredCommands,
 		func(l logger.Logger) {
 			l.Info("Started")
 		},

--- a/apps/scheduler/internal/timers/expired_commands.go
+++ b/apps/scheduler/internal/timers/expired_commands.go
@@ -1,0 +1,108 @@
+package timers
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/samber/lo"
+	config "github.com/satont/twir/libs/config"
+	model "github.com/satont/twir/libs/gomodels"
+	"github.com/satont/twir/libs/logger"
+	commandscache "github.com/twirapp/twir/libs/cache/commands"
+	generic_cacher "github.com/twirapp/twir/libs/cache/generic-cacher"
+	"go.uber.org/fx"
+	"gorm.io/gorm"
+)
+
+type ExpiredCommandsOpts struct {
+	fx.In
+	Lc fx.Lifecycle
+
+	Logger logger.Logger
+	Config config.Config
+
+	Gorm        *gorm.DB
+	RedisClient *redis.Client
+}
+
+type expiredCommands struct {
+	config        config.Config
+	logger        logger.Logger
+	db            *gorm.DB
+	commandsCache *generic_cacher.GenericCacher[[]model.ChannelsCommands]
+}
+
+func NewExpiredCommands(opts ExpiredCommandsOpts) *expiredCommands {
+	timeTick := lo.If(opts.Config.AppEnv != "production", 15*time.Second).Else(5 * time.Minute)
+	ticker := time.NewTicker(timeTick)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	s := &expiredCommands{
+		config:        opts.Config,
+		logger:        opts.Logger,
+		db:            opts.Gorm,
+		commandsCache: commandscache.New(opts.Gorm, opts.RedisClient),
+	}
+
+	opts.Lc.Append(
+		fx.Hook{
+			OnStart: func(_ context.Context) error {
+				go func() {
+					for {
+						select {
+						case <-ctx.Done():
+							ticker.Stop()
+							return
+						case <-ticker.C:
+							s.checkForExpiredCommands(ctx)
+						}
+					}
+				}()
+
+				return nil
+			},
+			OnStop: func(_ context.Context) error {
+				cancel()
+				return nil
+			},
+		},
+	)
+
+	return s
+}
+
+func (s *expiredCommands) checkForExpiredCommands(ctx context.Context) {
+	var commands []model.ChannelsCommands
+	if err := s.db.WithContext(ctx).Preload("Channel").Where(
+		`"expires_at" < ? AND "expired" = ?`,
+		time.Now().UTC(),
+		false,
+	).Find(&commands).Error; err != nil {
+		s.logger.Error("failed to get commands", slog.Any("err", err))
+		return
+	}
+
+	for _, c := range commands {
+		s.logger.Info("Command expired", slog.Any("command", c))
+		c.Expired = true
+
+		err := s.db.WithContext(ctx).Updates(
+			&c,
+		).Error
+		if err != nil {
+			s.logger.Error("failed to update command", slog.Any("err", err))
+		}
+
+		err = s.commandsCache.Invalidate(
+			ctx,
+			c.Channel.ID)
+		if err != nil {
+			s.logger.Error("failed to invalidate commands cache", slog.Any("err", err))
+			return
+		}
+
+	}
+}

--- a/frontend/dashboard/src/api/commands/commands.ts
+++ b/frontend/dashboard/src/api/commands/commands.ts
@@ -50,6 +50,8 @@ export const useCommandsApi = createGlobalState(() => {
 						name
 						color
 					}
+					expiredIn
+					expired
 				}
 			}
 		`),

--- a/frontend/dashboard/src/features/commands/composables/use-command-edit.ts
+++ b/frontend/dashboard/src/features/commands/composables/use-command-edit.ts
@@ -38,6 +38,7 @@ const defaultFormValue: EditableCommand = {
 	cooldownRolesIds: [],
 	enabledCategories: [],
 	module: 'CUSTOM',
+	expiredIn: 0,
 }
 
 export const useCommandEdit = createGlobalState(() => {

--- a/frontend/dashboard/src/features/commands/ui/edit-modal.vue
+++ b/frontend/dashboard/src/features/commands/ui/edit-modal.vue
@@ -25,9 +25,9 @@ import {
 	NGridItem,
 	NInput,
 	NInputGroup,
+
 	NInputGroupLabel,
 	NInputNumber,
-
 	NModal,
 	NSelect,
 	NSpace,
@@ -490,6 +490,14 @@ const showCategoryModal = ref(false)
 							<NInput
 								v-model:value="formValue.description" placeholder="Description" type="textarea"
 								autosize
+							/>
+						</NFormItem>
+						<NFormItem
+							:label="t('commands.modal.expiration.label')" path="expiredIn"
+						>
+							<NInputNumber
+								v-model:value="formValue.expiredIn"
+								:min="0"
 							/>
 						</NFormItem>
 

--- a/frontend/dashboard/src/locales/en.json
+++ b/frontend/dashboard/src/locales/en.json
@@ -132,6 +132,9 @@
       "gameCategories": {
         "label": "Enable command only in certain categories (leave empty for disable)"
       },
+      "expiration": {
+        "label": "Choose expiration time in minutes from now, 0 for not expiring",
+      },
       "description": {
         "label": "Command Description"
       },

--- a/libs/gomodels/channels_commands.go
+++ b/libs/gomodels/channels_commands.go
@@ -17,34 +17,36 @@ var (
 )
 
 type ChannelsCommands struct {
-	ID                        string         `gorm:"primaryKey;column:id;type:TEXT;default:uuid_generate_v4()" json:"id"`
-	Name                      string         `gorm:"column:name;type:TEXT;"                                    json:"name"`
-	Cooldown                  null.Int       `gorm:"column:cooldown;type:INT4;default:0;"                      json:"cooldown"                  swaggertype:"integer"`
-	CooldownType              string         `gorm:"column:cooldownType;type:VARCHAR;default:GLOBAL;"          json:"cooldownType"`
-	Enabled                   bool           `gorm:"column:enabled;type:BOOL;"                                 json:"enabled"`
-	Aliases                   pq.StringArray `gorm:"column:aliases;type:text[];default:[];"                    json:"aliases"`
-	Description               null.String    `gorm:"column:description;type:TEXT;"                             json:"description"               swaggertype:"string"`
-	Visible                   bool           `gorm:"column:visible;type:BOOL;"                                 json:"visible"`
-	ChannelID                 string         `gorm:"column:channelId;type:TEXT;"                               json:"channelId"`
-	Default                   bool           `gorm:"column:default;type:BOOL;default:false;"                   json:"default"`
-	DefaultName               null.String    `gorm:"column:defaultName;type:TEXT;"                             json:"defaultName"               swaggertype:"string"`
-	Module                    string         `gorm:"column:module;type:VARCHAR;default:CUSTOM;"                json:"module"`
-	IsReply                   bool           `gorm:"column:is_reply;type:BOOL;"                                json:"isReply"`
-	KeepResponsesOrder        bool           `gorm:"column:keepResponsesOrder;type:BOOL;"                      json:"keepResponsesOrder"`
-	DeniedUsersIDS            pq.StringArray `gorm:"column:deniedUsersIds;type:text[];default:[];"             json:"deniedUsersIds"`
-	AllowedUsersIDS           pq.StringArray `gorm:"column:allowedUsersIds;type:text[];default:[];"            json:"allowedUsersIds"`
-	RolesIDS                  pq.StringArray `gorm:"column:rolesIds;type:text[];default:[];"                   json:"rolesIds"`
-	OnlineOnly                bool           `gorm:"column:online_only;type:BOOL;"                             json:"onlineOnly"`
-	CooldownRolesIDs          pq.StringArray `gorm:"column:cooldown_roles_ids;type:text[];default:[];"         json:"cooldownRolesIds"`
-	EnabledCategories         pq.StringArray `gorm:"column:enabled_categories;type:text[];default:[];"         json:"enabledCategories"`
-	RequiredWatchTime         int            `gorm:"column:requiredWatchTime;type:INT4;default:0;"             json:"requiredWatchTime"`
-	RequiredMessages          int            `gorm:"column:requiredMessages;type:INT4;default:0;"              json:"requiredMessages"`
-	RequiredUsedChannelPoints int            `gorm:"column:requiredUsedChannelPoints;type:INT4;default:0;"     json:"requiredUsedChannelPoints"`
-
-	Channel   *Channels                    `gorm:"foreignKey:ChannelID"     json:"-"`
-	Responses []*ChannelsCommandsResponses `gorm:"foreignKey:CommandID"     json:"responses"`
-	GroupID   null.String                  `gorm:"column:groupId;type:UUID" json:"groupId"`
-	Group     *ChannelCommandGroup         `gorm:"foreignKey:GroupID"       json:"group"`
+	ID                        string                       `gorm:"primaryKey;column:id;type:TEXT;default:uuid_generate_v4()" json:"id"`
+	Name                      string                       `gorm:"column:name;type:TEXT;"                                    json:"name"`
+	Cooldown                  null.Int                     `gorm:"column:cooldown;type:INT4;default:0;"                      json:"cooldown"                  swaggertype:"integer"`
+	CooldownType              string                       `gorm:"column:cooldownType;type:VARCHAR;default:GLOBAL;"          json:"cooldownType"`
+	Enabled                   bool                         `gorm:"column:enabled;type:BOOL;"                                 json:"enabled"`
+	Aliases                   pq.StringArray               `gorm:"column:aliases;type:text[];default:[];"                    json:"aliases"`
+	Description               null.String                  `gorm:"column:description;type:TEXT;"                             json:"description"               swaggertype:"string"`
+	Visible                   bool                         `gorm:"column:visible;type:BOOL;"                                 json:"visible"`
+	ChannelID                 string                       `gorm:"column:channelId;type:TEXT;"                               json:"channelId"`
+	Default                   bool                         `gorm:"column:default;type:BOOL;default:false;"                   json:"default"`
+	DefaultName               null.String                  `gorm:"column:defaultName;type:TEXT;"                             json:"defaultName"               swaggertype:"string"`
+	Module                    string                       `gorm:"column:module;type:VARCHAR;default:CUSTOM;"                json:"module"`
+	IsReply                   bool                         `gorm:"column:is_reply;type:BOOL;"                                json:"isReply"`
+	KeepResponsesOrder        bool                         `gorm:"column:keepResponsesOrder;type:BOOL;"                      json:"keepResponsesOrder"`
+	DeniedUsersIDS            pq.StringArray               `gorm:"column:deniedUsersIds;type:text[];default:[];"             json:"deniedUsersIds"`
+	AllowedUsersIDS           pq.StringArray               `gorm:"column:allowedUsersIds;type:text[];default:[];"            json:"allowedUsersIds"`
+	RolesIDS                  pq.StringArray               `gorm:"column:rolesIds;type:text[];default:[];"                   json:"rolesIds"`
+	OnlineOnly                bool                         `gorm:"column:online_only;type:BOOL;"                             json:"onlineOnly"`
+	CooldownRolesIDs          pq.StringArray               `gorm:"column:cooldown_roles_ids;type:text[];default:[];"         json:"cooldownRolesIds"`
+	EnabledCategories         pq.StringArray               `gorm:"column:enabled_categories;type:text[];default:[];"         json:"enabledCategories"`
+	RequiredWatchTime         int                          `gorm:"column:requiredWatchTime;type:INT4;default:0;"             json:"requiredWatchTime"`
+	RequiredMessages          int                          `gorm:"column:requiredMessages;type:INT4;default:0;"              json:"requiredMessages"`
+	RequiredUsedChannelPoints int                          `gorm:"column:requiredUsedChannelPoints;type:INT4;default:0;"     json:"requiredUsedChannelPoints"`
+	ExpiresAt                 null.Time                    `gorm:"column:expires_at;type:TIMESTAMPTZ;"                       json:"expires_at"`
+	Expired                   bool                         `gorm:"column:expired;type:BOOL;default:false;"                   json:"expired"`
+	ExpiredIn                 int                          `gorm:"column:expired_in;type:INT4;default:0;"                    json:"expired_in"`
+	Channel                   *Channels                    `gorm:"foreignKey:ChannelID"                                      json:"-"`
+	Responses                 []*ChannelsCommandsResponses `gorm:"foreignKey:CommandID"                                      json:"responses"`
+	GroupID                   null.String                  `gorm:"column:groupId;type:UUID"                                  json:"groupId"`
+	Group                     *ChannelCommandGroup         `gorm:"foreignKey:GroupID"                                        json:"group"`
 }
 
 func (c *ChannelsCommands) TableName() string {

--- a/libs/migrations/migrations/20241025040229_commands_expiration.sql
+++ b/libs/migrations/migrations/20241025040229_commands_expiration.sql
@@ -1,0 +1,13 @@
+-- +goose Up
+-- +goose StatementBegin
+SELECT 'up SQL query';
+
+ALTER TABLE channels_commands ADD COLUMN expires_at timestamptz;
+ALTER TABLE channels_commands ADD COLUMN expired boolean default false;
+ALTER TABLE channels_commands ADD COLUMN expired_in integer DEFAULT 0;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+SELECT 'down SQL query';
+-- +goose StatementEnd


### PR DESCRIPTION
Resolved #639

This is implementation for supporting commands expiration.

Tested this via creating, updating some commands, and it's works. It can be some inconsistent state between db and cache but the chance is very low.

Proposals:
- Needs to somehow displays expired commands on frontend, but expired field already returning by gql and I just dunno how to do this.
- Can be added one more expiration date picker via Naive Date Picker, it's easy to work with this on backend but we need user timezones, so I decided this must be next PR.