### PR TITLE
feat(gql-api): community users filters

### DIFF
--- a/apps/api-gql/cmd/main.go
+++ b/apps/api-gql/cmd/main.go
@@ -4,6 +4,7 @@ import (
 	cfg "github.com/satont/twir/libs/config"
 	"github.com/twirapp/twir/apps/api-gql/internal/auth"
 	"github.com/twirapp/twir/apps/api-gql/internal/gql"
+	community_searcher "github.com/twirapp/twir/apps/api-gql/internal/gql/community-searcher"
 	"github.com/twirapp/twir/apps/api-gql/internal/gql/directives"
 	"github.com/twirapp/twir/apps/api-gql/internal/gql/resolvers"
 	twir_stats "github.com/twirapp/twir/apps/api-gql/internal/gql/twir-stats"
@@ -51,6 +52,7 @@ func main() {
 			directives.New,
 			httpserver.New,
 			gql.New,
+			community_searcher.NewCommunitySearcher,
 		),
 		fx.Invoke(
 			pubclicroutes.New,

--- a/apps/api-gql/internal/gql/community-searcher/community-searcher.go
+++ b/apps/api-gql/internal/gql/community-searcher/community-searcher.go
@@ -1,0 +1,102 @@
+package community_searcher
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type FieldType int
+
+const (
+	IntegerType FieldType = iota
+	DateType
+	StringType
+)
+
+type CommunitySearcher struct {
+	SearchFields  map[string]FieldType
+	searchPattern string
+}
+
+type Condition struct {
+	Field    string
+	Operator string
+	Value    interface{}
+	Type     FieldType
+}
+type ParsedSearchQuery struct {
+	Conditions []Condition
+	Username   string
+}
+
+var defaultFields = map[string]FieldType{
+	"messages":          IntegerType,
+	"usedChannelPoints": IntegerType,
+	"emotes":            IntegerType,
+	"watched":           IntegerType,
+}
+
+const defaultSearchPattern = `(\w+):([><]=?|=)(\S+)`
+
+func NewCommunitySearcher() *CommunitySearcher {
+	return &CommunitySearcher{
+		SearchFields:  defaultFields,
+		searchPattern: defaultSearchPattern,
+	}
+}
+
+func (cs *CommunitySearcher) ParseSearchQuery(query string) (*ParsedSearchQuery, error) {
+	re := regexp.MustCompile(cs.searchPattern)
+	matches := re.FindAllStringSubmatch(query, -1)
+
+	var conditions []Condition
+	var username string
+
+	remainingTokens := query
+	for _, match := range matches {
+		field := match[1]
+		operator := match[2]
+		rawValue := match[3]
+
+		fieldType, exists := cs.SearchFields[field]
+		if !exists {
+			return nil, fmt.Errorf("unknown field: %s", field)
+		}
+
+		var value interface{}
+		var err error
+		switch fieldType {
+		case IntegerType:
+			value, err = strconv.Atoi(rawValue)
+		case DateType:
+			value, err = time.Parse("2006-01-02", rawValue) // "YYYY-MM-DD"
+		case StringType:
+			value = rawValue
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		conditions = append(conditions, Condition{
+			Field:    field,
+			Operator: operator,
+			Value:    value,
+			Type:     fieldType,
+		})
+
+		remainingTokens = strings.Replace(remainingTokens, match[0], "", 1)
+		remainingTokens = strings.TrimSpace(remainingTokens)
+	}
+
+	if remainingTokens != "" && username == "" {
+		username = strings.Fields(remainingTokens)[0]
+	}
+
+	return &ParsedSearchQuery{
+		Conditions: conditions,
+		Username:   username,
+	}, nil
+}

--- a/apps/api-gql/internal/gql/community-searcher/community-searcher_test.go
+++ b/apps/api-gql/internal/gql/community-searcher/community-searcher_test.go
@@ -1,0 +1,150 @@
+package community_searcher
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func mustParseDate(value string) time.Time {
+	date, err := time.Parse("2006-01-02", value)
+	if err != nil {
+		panic(err)
+	}
+	return date
+}
+
+func TestParseQuery(t *testing.T) {
+	tests := []struct {
+		name        string
+		query       string
+		expected    ParsedSearchQuery
+		expectError bool
+	}{
+		{
+			name:  "Basic integer query with two filters",
+			query: "TwirApp messages:>=50 usedChannelPoints:<=100",
+			expected: ParsedSearchQuery{
+				Username: "TwirApp",
+				Conditions: []Condition{
+					{Field: "messages", Operator: ">=", Value: 50, Type: IntegerType},
+					{Field: "usedChannelPoints", Operator: "<=", Value: 100, Type: IntegerType},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name:  "Two fields without username",
+			query: "messages:>2 emotes:>30",
+			expected: ParsedSearchQuery{
+				Username: "",
+				Conditions: []Condition{
+					{Field: "messages", Operator: ">", Value: 2, Type: IntegerType},
+					{Field: "emotes", Operator: ">", Value: 30, Type: IntegerType},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name:  "Simple query with only one filter",
+			query: "TwirApp messages:>=50",
+			expected: ParsedSearchQuery{
+				Username: "TwirApp",
+				Conditions: []Condition{
+					{Field: "messages", Operator: ">=", Value: 50, Type: IntegerType},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name:  "Multiple usernames and one filter, so, just take first one",
+			query: "TwirApp messages:>=50 MellKam",
+			expected: ParsedSearchQuery{
+				Username: "TwirApp",
+				Conditions: []Condition{
+					{Field: "messages", Operator: ">=", Value: 50, Type: IntegerType},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name:        "Unsupported field",
+			query:       "TwirApp unknown_field:>=50",
+			expected:    ParsedSearchQuery{},
+			expectError: true,
+		},
+		{
+			name:        "Invalid integer value",
+			query:       "messages:>=abc",
+			expected:    ParsedSearchQuery{},
+			expectError: true,
+		},
+		{
+			name:  "Username without explicit field",
+			query: "TwirApp",
+			expected: ParsedSearchQuery{
+				Username:   "TwirApp",
+				Conditions: []Condition{},
+			},
+			expectError: false,
+		},
+		{
+			name:  "Empty query",
+			query: "",
+			expected: ParsedSearchQuery{
+				Username:   "",
+				Conditions: []Condition{},
+			},
+			expectError: false,
+		},
+		{
+			name:        "Invalid syntax must behave as empty search",
+			query:       "TwirAppunknown_field:>=50 gsgs",
+			expected:    ParsedSearchQuery{},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cs := NewCommunitySearcher()
+			result, err := cs.ParseSearchQuery(tt.query)
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("Expected error but got none")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+				return
+			}
+
+			if result.Username != tt.expected.Username {
+				t.Errorf("Expected username %q, got %q", tt.expected.Username, result.Username)
+			}
+
+			if len(result.Conditions) != len(tt.expected.Conditions) {
+				t.Fatalf(
+					"Expected %d conditions, got %d",
+					len(tt.expected.Conditions),
+					len(result.Conditions),
+				)
+			}
+			for i, expectedCondition := range tt.expected.Conditions {
+				actualCondition := result.Conditions[i]
+				if actualCondition.Field != expectedCondition.Field ||
+					actualCondition.Operator != expectedCondition.Operator ||
+					actualCondition.Type != expectedCondition.Type ||
+					!reflect.DeepEqual(actualCondition.Value, expectedCondition.Value) {
+					t.Errorf(
+						"Condition mismatch at index %d: expected %+v, got %+v",
+						i,
+						expectedCondition,
+						actualCondition,
+					)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Resolved #714

Now it's possible to do queries like messages:>=50 on community users page, multiple filters also supported. But the behavior is better explained in tests for community_search module.

The syntax is pretty similar as in github search.

**Proposals:**
Somehow display this in community page. I think good place is to do this in placeholder but help needed because I think it's possible to add something like syntax helper which will be nice task for frontend.

