### PR TITLE
chore(dashboard): capitalize bot settings tab name

### DIFF
--- a/frontend/dashboard/src/features/bot-settings/bot-settings.vue
+++ b/frontend/dashboard/src/features/bot-settings/bot-settings.vue
@@ -7,7 +7,7 @@ import PageLayout from '@/layout/page-layout.vue'
 <template>
 	<PageLayout>
 		<template #title>
-			Bot settings
+			Bot Settings
 		</template>
 
 		<template #content>

--- a/frontend/dashboard/src/layout/sidebar/sidebar-navigation.vue
+++ b/frontend/dashboard/src/layout/sidebar/sidebar-navigation.vue
@@ -75,7 +75,7 @@ const links = computed(() => {
 			path: '/dashboard',
 		},
 		{
-			name: 'Bot settings',
+			name: 'Bot Settings',
 			icon: SettingsIcon,
 			path: '/dashboard/bot-settings',
 			isNew: true,


### PR DESCRIPTION
As a perfectionist, it hurts me to look at the differences in the naming of tabs, so I suggest sticking to one style (each word with a capital letter) :)