### PR TITLE
feat(landing): remove "streamers" from anchor-links

### DIFF
--- a/web/layers/landing/layouts/default/anchor-links.ts
+++ b/web/layers/landing/layouts/default/anchor-links.ts
@@ -8,10 +8,6 @@ export const anchorLinks = [
 		label: 'Integrations',
 	},
 	{
-		href: '#streamers',
-		label: 'Streamers',
-	},
-	{
 		href: '#team',
 		label: 'Team',
 	},


### PR DESCRIPTION
Remove the "streamers" from anchor links. The section on the site has been deleted, but they forgot to remove it from the links.