### PR TITLE
perf(bots): use bulk insert for messages and used emotes

### DIFF
--- a/apps/bots/app/app.go
+++ b/apps/bots/app/app.go
@@ -34,6 +34,8 @@ import (
 	channelsrepositorypgx "github.com/twirapp/twir/libs/repositories/channels/pgx"
 	channelscommandsprefixrepository "github.com/twirapp/twir/libs/repositories/channels_commands_prefix"
 	channelscommandsprefixpgx "github.com/twirapp/twir/libs/repositories/channels_commands_prefix/pgx"
+	channelsemotesusagesrepository "github.com/twirapp/twir/libs/repositories/channels_emotes_usages"
+	channelsemotesusagesrepositorypgx "github.com/twirapp/twir/libs/repositories/channels_emotes_usages/pgx"
 	channelsmoderationsettingsrepository "github.com/twirapp/twir/libs/repositories/channels_moderation_settings"
 	channelsmoderationsettingsrepositorypostgres "github.com/twirapp/twir/libs/repositories/channels_moderation_settings/datasource/postgres"
 	chatmessagesrepository "github.com/twirapp/twir/libs/repositories/chat_messages"
@@ -97,6 +99,10 @@ var App = fx.Module(
 		fx.Annotate(
 			channelsmoderationsettingsrepositorypostgres.NewFx,
 			fx.As(new(channelsmoderationsettingsrepository.Repository)),
+		),
+		fx.Annotate(
+			channelsemotesusagesrepositorypgx.NewFx,
+			fx.As(new(channelsemotesusagesrepository.Repository)),
 		),
 	),
 	fx.Provide(

--- a/apps/bots/internal/messagehandler/handle_remove_lurker.go
+++ b/apps/bots/internal/messagehandler/handle_remove_lurker.go
@@ -50,8 +50,7 @@ func (c *MessageHandler) handleRemoveLurkerBatched(ctx context.Context, data []h
 	}
 }
 
-func (c *MessageHandler) handleRemoveLurker(ctx context.Context, msg handleMessage) error {
+func (c *MessageHandler) handleRemoveLurker(_ context.Context, msg handleMessage) error {
 	c.messagesLurkersBatcher.Add(msg)
-
 	return nil
 }

--- a/apps/bots/internal/messagehandler/handle_save_message.go
+++ b/apps/bots/internal/messagehandler/handle_save_message.go
@@ -4,35 +4,32 @@ import (
 	"context"
 	"log/slog"
 
-	"github.com/twirapp/twir/libs/repositories/chat_messages"
+	chatmessages "github.com/twirapp/twir/libs/repositories/chat_messages"
 )
 
-// var handleSaveMessagesQueue []handleMessage
-// var handleSaveMessagesQueueLock sync.Mutex
-
 func (c *MessageHandler) handleSaveMessageBatched(ctx context.Context, data []handleMessage) {
-	for _, msg := range data {
-		err := c.chatMessagesRepository.Create(
-			ctx,
-			chat_messages.CreateInput{
-				ID:              msg.ID,
-				ChannelID:       msg.BroadcasterUserId,
-				UserID:          msg.ChatterUserId,
-				Text:            msg.Message.Text,
-				UserName:        msg.ChatterUserLogin,
-				UserDisplayName: msg.ChatterUserName,
-				UserColor:       msg.Color,
-			},
-		)
-		if err != nil {
-			c.logger.Error("cannot save chat message to db", slog.Any("err", err))
-			continue
+	createMessageInputs := make([]chatmessages.CreateInput, len(data))
+
+	for index, msg := range data {
+		createMessageInputs[index] = chatmessages.CreateInput{
+			ID:              msg.ID,
+			ChannelID:       msg.BroadcasterUserId,
+			UserID:          msg.ChatterUserId,
+			Text:            msg.Message.Text,
+			UserName:        msg.ChatterUserLogin,
+			UserDisplayName: msg.ChatterUserName,
+			UserColor:       msg.Color,
 		}
+	}
+
+	err := c.chatMessagesRepository.CreateMany(ctx, createMessageInputs)
+	if err != nil {
+		c.logger.Error("cannot save chat messages to db", slog.Any("err", err))
 	}
 }
 
 func (c *MessageHandler) handleSaveMessage(
-	ctx context.Context,
+	_ context.Context,
 	msg handleMessage,
 ) error {
 	if msg.Message == nil {

--- a/apps/bots/internal/messagehandler/messagehandler.go
+++ b/apps/bots/internal/messagehandler/messagehandler.go
@@ -26,6 +26,7 @@ import (
 	"github.com/twirapp/twir/libs/grpc/parser"
 	"github.com/twirapp/twir/libs/grpc/websockets"
 	channelsrepository "github.com/twirapp/twir/libs/repositories/channels"
+	"github.com/twirapp/twir/libs/repositories/channels_emotes_usages"
 	channelsmoderationsettingsmodel "github.com/twirapp/twir/libs/repositories/channels_moderation_settings/model"
 	"github.com/twirapp/twir/libs/repositories/chat_messages"
 	chatwallrepository "github.com/twirapp/twir/libs/repositories/chat_wall"
@@ -46,6 +47,7 @@ type Opts struct {
 	WebsocketsGrpc                   websockets.WebsocketClient
 	GreetingsRepository              greetings.Repository
 	ChatMessagesRepository           chat_messages.Repository
+	ChannelsEmotesUsagesRepository   channels_emotes_usages.Repository
 	Gorm                             *gorm.DB
 	Redis                            *redis.Client
 	TwitchActions                    *twitchactions.TwitchActions
@@ -71,6 +73,7 @@ type MessageHandler struct {
 	websocketsGrpc                   websockets.WebsocketClient
 	greetingsRepository              greetings.Repository
 	chatMessagesRepository           chat_messages.Repository
+	channelsEmotesUsagesRepository   channels_emotes_usages.Repository
 	gorm                             *gorm.DB
 	redis                            *redis.Client
 	twitchActions                    *twitchactions.TwitchActions
@@ -111,6 +114,7 @@ func New(opts Opts) *MessageHandler {
 		keywordsService:                  opts.KeywordsService,
 		greetingsRepository:              opts.GreetingsRepository,
 		chatMessagesRepository:           opts.ChatMessagesRepository,
+		channelsEmotesUsagesRepository:   opts.ChannelsEmotesUsagesRepository,
 		greetingsCache:                   opts.GreetingsCache,
 		ttsService:                       opts.TTSService,
 		chatWallCacher:                   opts.ChatWallCacher,
@@ -126,8 +130,8 @@ func New(opts Opts) *MessageHandler {
 
 	handler.messagesSaveBatcher = batchprocessor.NewBatchProcessor[handleMessage](
 		batchprocessor.BatchProcessorOpts[handleMessage]{
-			Interval:  100 * time.Millisecond,
-			BatchSize: 100,
+			Interval:  500 * time.Millisecond,
+			BatchSize: 1000,
 			Callback:  handler.handleSaveMessageBatched,
 		},
 	)
@@ -140,8 +144,8 @@ func New(opts Opts) *MessageHandler {
 	)
 	handler.messagesEmotesBatcher = batchprocessor.NewBatchProcessor[handleMessage](
 		batchprocessor.BatchProcessorOpts[handleMessage]{
-			Interval:  100 * time.Millisecond,
-			BatchSize: 200,
+			Interval:  500 * time.Millisecond,
+			BatchSize: 1000,
 			Callback:  handler.handleEmotesUsagesBatched,
 		},
 	)

--- a/libs/repositories/channels_emotes_usages/channels_emotes_usages.go
+++ b/libs/repositories/channels_emotes_usages/channels_emotes_usages.go
@@ -1,0 +1,18 @@
+package channels_emotes_usages
+
+import (
+	"context"
+	"time"
+)
+
+type Repository interface {
+	CreateMany(ctx context.Context, inputs []ChannelEmoteUsageInput) error
+}
+
+type ChannelEmoteUsageInput struct {
+	ID        string
+	ChannelID string
+	UserID    string
+	Emote     string
+	CreatedAt time.Time
+}

--- a/libs/repositories/channels_emotes_usages/pgx/pgx.go
+++ b/libs/repositories/channels_emotes_usages/pgx/pgx.go
@@ -1,0 +1,62 @@
+package pgx
+
+import (
+	"context"
+	"fmt"
+
+	trmpgx "github.com/avito-tech/go-transaction-manager/drivers/pgxv5/v2"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/twirapp/twir/libs/repositories/channels_emotes_usages"
+)
+
+type Opts struct {
+	PgxPool *pgxpool.Pool
+}
+
+func New(opts Opts) *Pgx {
+	return &Pgx{
+		pool:   opts.PgxPool,
+		getter: trmpgx.DefaultCtxGetter,
+	}
+}
+
+func NewFx(pool *pgxpool.Pool) *Pgx {
+	return New(Opts{PgxPool: pool})
+}
+
+var _ channels_emotes_usages.Repository = (*Pgx)(nil)
+
+type Pgx struct {
+	pool   *pgxpool.Pool
+	getter *trmpgx.CtxGetter
+}
+
+func (p Pgx) CreateMany(
+	ctx context.Context,
+	inputs []channels_emotes_usages.ChannelEmoteUsageInput,
+) error {
+	conn := p.getter.DefaultTrOrDB(ctx, p.pool)
+	_, err := conn.CopyFrom(
+		ctx,
+		pgx.Identifier{"channels_emotes_usages"},
+		[]string{"id", "channelId", "userId", "createdAt", "emote"},
+		pgx.CopyFromSlice(
+			len(inputs),
+			func(i int) ([]any, error) {
+				return []any{
+					inputs[i].ID,
+					inputs[i].ChannelID,
+					inputs[i].UserID,
+					inputs[i].CreatedAt,
+					inputs[i].Emote,
+				}, nil
+			},
+		),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to copy from: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
Batch limits for chat messages and used emotes are increased and bulk inserts are used instead of one-by-one inserts.