### PR TITLE
fix: design valorant widget, font, height and font size for switch toggle

### DIFF
--- a/frontend/dashboard/src/components/ui/switch/SwitchToggle.vue
+++ b/frontend/dashboard/src/components/ui/switch/SwitchToggle.vue
@@ -26,7 +26,7 @@ function updateValue() {
 		:id="id"
 		type="button"
 		:aria-checked="modelValue"
-		class="inline-flex h-8 cursor-pointer min-w-24 items-center justify-between rounded-md border border-white/10 p-1 font-mono text-sm transition-all duration-200 hover:border-white/15 hover:bg-white/5"
+		class="inline-flex h-9 cursor-pointer min-w-24 items-center justify-between rounded-md border border-white/10 p-1 text-xs transition-all duration-200 hover:border-white/15 hover:bg-white/5"
 		:disabled="disabled"
 		:style="{ opacity: disabled ? '0.5' : '1' }"
 		@click="updateValue"

--- a/libs/frontend-valorant-stats/src/widget.vue
+++ b/libs/frontend-valorant-stats/src/widget.vue
@@ -27,8 +27,8 @@ const props = withDefaults(
 	{
 		settings: () => ({
 			backgroundColor: '#07090e',
-			textColor: '#f2f2f2',
-			primaryTextColor: '#B9B4B4',
+			textColor: '#FFFFFF',
+			primaryTextColor: '#FFFFFF',
 			winColor: '#00FFE3',
 			loseColor: '#FF7986',
 
@@ -229,7 +229,7 @@ const rankSrc = computed(() => {
 				<div class="inline-flex items-center justify-center gap-2">
 					<div class="relative">
 						<div class="relative flex">
-							<img :src="rankSrc" class="z-2" alt="" height="40" width="40" fetchpriority="high" />
+							<img :src="rankSrc" class="z-10" alt="" height="40" width="40" fetchpriority="high" />
 							<img
 								v-if="!settings.disabledGlowEffect"
 								class="absolute top-1/2 left-1/2 size-10 max-w-[unset] -translate-x-1/2 -translate-y-1/2 transform blur-[10px]"
@@ -239,7 +239,7 @@ const rankSrc = computed(() => {
 							/>
 						</div>
 						<span
-							class="absolute top-0 right-0 z-2 flex size-4 flex-col items-center justify-center rounded-full bg-white text-sm leading-none font-medium text-black"
+							class="absolute top-0 right-0 z-10 flex size-4 flex-col items-center justify-center rounded-full bg-white text-sm leading-none font-medium text-black"
 						>
 							{{ stats.mmr.current.tier.name.split(' ').at(-1) }}
 						</span>


### PR DESCRIPTION
Поправил дефолтные цвета для Valorant виджета, чтобы смотрелось лучше и пофиксил z-index для Rank Icon, чтобы glow effect не налезал на основной значок.
Убрал font mono для Switch Toggle, чтобы органично смотрелось с другими UI элементами, также чуть-чуть изменил высоту компонента и размер шрифта 