### PR TITLE
chore(deps): update oxc packages to latest versions

### DIFF
--- a/.oxfmtrc.jsonc
+++ b/.oxfmtrc.jsonc
@@ -14,19 +14,25 @@
 	"sortImports": {
 		"newlinesBetween": true,
 		"ignoreCase": true,
+		"order": "asc",
+		"internalPattern": ["~/", "@/"],
 		"groups": [
-			["value-builtin", "value-external"],
-			["value-internal", "value-parent", "value-sibling", "value-index"],
+			["type-builtin", "type-external"],
+			"value-builtin",
+			"value-external",
 			{ "newlinesBetween": true },
-			"type-import",
-			"unknown"
-		]
+			"type-internal",
+			"value-internal",
+			["type-parent", "type-sibling", "type-index"],
+			["value-parent", "value-sibling", "value-index"],
+			"unknown",
+		],
 	},
 	"sortTailwindcss": {
 		"functions": ["clsx", "cn"],
 		"preserveWhitespace": true,
-		"preserveDuplicates": true
+		"preserveDuplicates": true,
 	},
 	"singleAttributePerLine": true,
-	"ignorePatterns": ["dist/**", "node_modules/**", "build/**", ".output", ".nuxt"]
+	"ignorePatterns": ["dist/**", "node_modules/**", "build/**", ".output", ".nuxt"],
 }

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -248,10 +248,7 @@
         "@typescript-eslint/prefer-as-const": "error",
         "@typescript-eslint/prefer-literal-enum-member": "error",
         "@typescript-eslint/triple-slash-reference": "off",
-        "@typescript-eslint/consistent-type-definitions": [
-          "error",
-          "interface"
-        ],
+        "@typescript-eslint/consistent-type-definitions": ["error", "interface"],
         "@typescript-eslint/consistent-type-imports": "error",
         "@typescript-eslint/no-import-type-side-effects": "error",
         "@typescript-eslint/no-require-imports": "error",
@@ -312,6 +309,15 @@
         "vue/no-multiple-slot-args": "warn"
       },
       "plugins": ["vue"]
+    },
+    {
+      "files": [
+        "frontend/dashboard/src/components/dashboard/custom-widget.vue",
+        "frontend/dashboard/src/pages/settings/custom-widgets.vue"
+      ],
+      "rules": {
+        "no-alert": "off"
+      }
     }
   ]
 }

--- a/apps/integrations/src/index.ts
+++ b/apps/integrations/src/index.ts
@@ -1,100 +1,96 @@
-import { IntegrationService } from '@twir/bus-core'
-import process from 'node:process'
-
-import type { Integration } from './libs/db'
+import { IntegrationService } from '@twir/bus-core';
+import process from 'node:process';
 
 import {
-	Service,
 	getDonationAlertsIntegrations,
 	getDonationPayIntegrations,
-	getIntegrations,
 	getStreamlabsIntegrations,
-} from './libs/db'
-import { twirBus } from './libs/twirbus.ts'
+} from './libs/db';
+import { twirBus } from './libs/twirbus.ts';
 import {
 	addIntegration as addDonatePayIntegration,
 	removeIntegration as removeDonatePayIntegration,
-} from './store/donatePay'
+} from './store/donatePay';
 import {
 	addIntegration as addDonationAlertsIntegration,
 	removeIntegration as removeDonationAlertsIntegration,
-} from './store/donationAlerts'
+} from './store/donationAlerts';
 import {
 	addIntegration as addStreamlabsIntegration,
 	removeIntegration as removeStreamlabsIntegration,
-} from './store/streamlabs'
-import './pubsub'
+} from './store/streamlabs';
+import './pubsub';
 
 for (const donatePayIntegration of await getDonationPayIntegrations()) {
-	addDonatePayIntegration(donatePayIntegration)
+	addDonatePayIntegration(donatePayIntegration);
 }
 
 for (const integration of await getDonationAlertsIntegrations()) {
-	addDonationAlertsIntegration(integration)
+	addDonationAlertsIntegration(integration);
 }
 
 for (const integration of await getStreamlabsIntegrations()) {
-	addStreamlabsIntegration(integration)
+	addStreamlabsIntegration(integration);
 }
 
 twirBus.Integrations.Add.subscribe(async (data) => {
-	console.info(`Adding ${data.id} (${data.service}) connection`)
+	console.info(`Adding ${data.id} (${data.service}) connection`);
 
 	if (data.service === IntegrationService.DONATEPAY) {
-		const integration = await getDonationPayIntegrations({ id: data.id })
+		const integration = await getDonationPayIntegrations({ id: data.id });
 		if (!integration) {
-			console.error(`Integration with id ${data.id} not found for DonatePay`)
-			return null
+			console.error(`Integration with id ${data.id} not found for DonatePay`);
+			return null;
 		}
-		await addDonatePayIntegration(integration)
-		return
+		await addDonatePayIntegration(integration);
+		return;
 	}
 
 	if (data.service === IntegrationService.DONATIONALERTS) {
-		const integration = await getDonationAlertsIntegrations({ id: Number(data.id) })
+		const integration = await getDonationAlertsIntegrations({ id: Number(data.id) });
 		if (!integration) {
-			console.error(`Integration with id ${data.id} not found for DonateAlerts`)
-			return null
+			console.error(`Integration with id ${data.id} not found for DonateAlerts`);
+			return null;
 		}
-		await addDonationAlertsIntegration(integration)
-		return
+		await addDonationAlertsIntegration(integration);
+		return;
 	}
 
 	if (data.service === IntegrationService.STREAMLABS) {
-		const integration = await getStreamlabsIntegrations({ id: data.id })
+		const integration = await getStreamlabsIntegrations({ id: data.id });
 		if (!integration) {
-			console.error(`Integration with id ${data.id} not found for Streamlabs`)
-			return null
+			console.error(`Integration with id ${data.id} not found for Streamlabs`);
+			return null;
 		}
-		await addStreamlabsIntegration(integration)
-		return
+		await addStreamlabsIntegration(integration);
+		return;
 	}
 
-	return null
-})
+	return null;
+});
 
 twirBus.Integrations.Remove.subscribe(async (data) => {
-	console.info(`Destroying ${data.id} (${data.service}) connection`)
+	console.info(`Destroying ${data.id} (${data.service}) connection`);
 
 	if (data.service === IntegrationService.DONATEPAY) {
-		await removeDonatePayIntegration(data.id) // channelId
-		return null
+		await removeDonatePayIntegration(data.id); // channelId
+		return null;
 	}
 
 	if (data.service === IntegrationService.DONATIONALERTS) {
-		await removeDonationAlertsIntegration(data.id) // channelId
-		return null
+		await removeDonationAlertsIntegration(data.id); // channelId
+		return null;
 	}
 
 	if (data.service === IntegrationService.STREAMLABS) {
-		await removeStreamlabsIntegration(data.id) // channelId
-		return null
+		await removeStreamlabsIntegration(data.id); // channelId
+		return null;
 	}
 
-	return null
-})
+	return null;
+});
 
-console.info('Integrations started')
+console.info('Integrations started');
 
-process.on('uncaughtException', console.error)
-process.on('unhandledRejection', console.error)
+process.on('uncaughtException', console.error);
+process.on('unhandledRejection', console.error);

--- a/apps/integrations/src/store/donationAlerts.ts
+++ b/apps/integrations/src/store/donationAlerts.ts
@@ -1,32 +1,32 @@
-import { sleep } from 'bun'
+import { sleep } from 'bun';
 
+import { DonationAlertsIntegration, updateDonationAlertsIntegration } from '../libs/db.ts';
 import {
-	DonationAlertsIntegration,
-	updateDonationAlertsIntegration,
-	updateIntegration,
-} from '../libs/db.ts'
-import { DonationAlerts, globalRequestLimiter, rateLimiterKey } from '../services/donationAlerts.ts'
-import { config } from '@twir/config'
+	DonationAlerts,
+	globalRequestLimiter,
+	rateLimiterKey,
+} from '../services/donationAlerts.ts';
+import { config } from '@twir/config';
 
-export const donationAlertsStore = new Map<string, DonationAlerts>()
+export const donationAlertsStore = new Map<string, DonationAlerts>();
 
 export async function addIntegration(integration: DonationAlertsIntegration) {
 	if (!integration.access_token || !integration.refresh_token || !integration.enabled) {
-		return
+		return;
 	}
 
 	if (donationAlertsStore.get(integration.channel_id)) {
-		await removeIntegration(integration.channel_id)
+		await removeIntegration(integration.channel_id);
 	}
 
-	let accessToken
-	let refreshToken
+	let accessToken;
+	let refreshToken;
 
 	while (true) {
-		const { isAllowed } = await globalRequestLimiter.consume(rateLimiterKey)
+		const { isAllowed } = await globalRequestLimiter.consume(rateLimiterKey);
 		if (!isAllowed) {
-			await sleep(1000)
-			continue
+			await sleep(1000);
+			continue;
 		}
 
 		try {
@@ -41,89 +41,89 @@ export async function addIntegration(integration: DonationAlertsIntegration) {
 					client_id: config.DONATIONALERTS_CLIENT_ID!,
 					client_secret: config.DONATIONALERTS_CLIENT_SECRET!,
 				}).toString(),
-			})
+			});
 
 			if (!refresh.ok) {
 				if (refresh.status === 429) {
-					await sleep(1000)
-					continue
+					await sleep(1000);
+					continue;
 				}
-				console.error('cannot refresh DA tokens:', await refresh.text())
-				break
+				console.error('cannot refresh DA tokens:', await refresh.text());
+				break;
 			}
 
-			const refreshResponse = await refresh.json()
-			accessToken = refreshResponse.access_token
-			refreshToken = refreshResponse.refresh_token
-			break
+			const refreshResponse = await refresh.json();
+			accessToken = refreshResponse.access_token;
+			refreshToken = refreshResponse.refresh_token;
+			break;
 		} catch (e) {
-			console.log(e)
-			await sleep(1000)
-			continue
+			console.log(e);
+			await sleep(1000);
+			continue;
 		}
 	}
 
 	if (!accessToken || !refreshToken) {
-		return
+		return;
 	}
 
 	await updateDonationAlertsIntegration({
 		channel_id: integration.channel_id,
 		access_token: accessToken,
 		refresh_token: refreshToken,
-	})
+	});
 
-	let profileData
+	let profileData;
 
 	while (true) {
-		const { isAllowed } = await globalRequestLimiter.consume(rateLimiterKey)
+		const { isAllowed } = await globalRequestLimiter.consume(rateLimiterKey);
 		if (!isAllowed) {
-			await sleep(1000)
-			continue
+			await sleep(1000);
+			continue;
 		}
 
 		const request = await fetch('https://www.donationalerts.com/api/v1/user/oauth', {
 			headers: {
 				Authorization: `Bearer ${accessToken}`,
 			},
-		})
+		});
 
 		if (!request.ok) {
 			if (request.status === 429) {
-				await sleep(1000)
-				continue
+				await sleep(1000);
+				continue;
 			}
-			console.error('cannot get donationAlerts profile', await request.text())
-			break
+			console.error('cannot get donationAlerts profile', await request.text());
+			break;
 		}
 
-		const response = await request.json()
-		profileData = response.data
-		break
+		const response = await request.json();
+		profileData = response.data;
+		break;
 	}
 
 	if (!profileData) {
-		return
+		return;
 	}
 
-	const { id, socket_connection_token } = profileData
+	const { id, socket_connection_token } = profileData;
 	const instance = new DonationAlerts(
 		accessToken,
 		id,
 		socket_connection_token,
-		integration.channel_id
-	)
-	await instance.init()
+		integration.channel_id,
+	);
+	await instance.init();
 
-	donationAlertsStore.set(integration.channel_id, instance)
+	donationAlertsStore.set(integration.channel_id, instance);
 
-	return instance
+	return instance;
 }
 
 export async function removeIntegration(channelId: string) {
-	const existed = donationAlertsStore.get(channelId)
-	if (!existed) return
+	const existed = donationAlertsStore.get(channelId);
+	if (!existed) return;
 
-	await existed.destroy()
-	donationAlertsStore.delete(channelId)
+	await existed.destroy();
+	donationAlertsStore.delete(channelId);
 }

--- a/bun.lock
+++ b/bun.lock
@@ -7,9 +7,9 @@
       "devDependencies": {
         "@types/bun": "catalog:",
         "@types/node": "25.0.3",
-        "oxfmt": "0.40.0",
-        "oxlint": "1.55.0",
-        "oxlint-tsgolint": "0.16.0",
+        "oxfmt": "0.44.0",
+        "oxlint": "1.59.0",
+        "oxlint-tsgolint": "0.20.0",
         "prettier": "3.6.2",
         "rimraf": "5.0.5",
         "typescript": "catalog:",
@@ -1037,93 +1037,93 @@
 
     "@oxc-transform/binding-win32-x64-msvc": ["@oxc-transform/binding-win32-x64-msvc@0.117.0", "", { "os": "win32", "cpu": "x64" }, "sha512-V7YzavQnYcRJBeJkp0qpb3FKrlm5I57XJetCYB4jsjStuboQmnFMZ/XQH55Szlf/kVyeU9ddQwv72gJJ5BrGjQ=="],
 
-    "@oxfmt/binding-android-arm-eabi": ["@oxfmt/binding-android-arm-eabi@0.40.0", "", { "os": "android", "cpu": "arm" }, "sha512-S6zd5r1w/HmqR8t0CTnGjFTBLDq2QKORPwriCHxo4xFNuhmOTABGjPaNvCJJVnrKBLsohOeiDX3YqQfJPF+FXw=="],
+    "@oxfmt/binding-android-arm-eabi": ["@oxfmt/binding-android-arm-eabi@0.44.0", "", { "os": "android", "cpu": "arm" }, "sha512-5UvghMd9SA/yvKTWCAxMAPXS1d2i054UeOf4iFjZjfayTwCINcC3oaSXjtbZfCaEpxgJod7XiOjTtby5yEv/BQ=="],
 
-    "@oxfmt/binding-android-arm64": ["@oxfmt/binding-android-arm64@0.40.0", "", { "os": "android", "cpu": "arm64" }, "sha512-/mbS9UUP/5Vbl2D6osIdcYiP0oie63LKMoTyGj5hyMCK/SFkl3EhtyRAfdjPvuvHC0SXdW6ePaTKkBSq1SNcIw=="],
+    "@oxfmt/binding-android-arm64": ["@oxfmt/binding-android-arm64@0.44.0", "", { "os": "android", "cpu": "arm64" }, "sha512-IVudM1BWfvrYO++Khtzr8q9n5Rxu7msUvoFMqzGJVdX7HfUXUDHwaH2zHZNB58svx2J56pmCUzophyaPFkcG/A=="],
 
-    "@oxfmt/binding-darwin-arm64": ["@oxfmt/binding-darwin-arm64@0.40.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-wRt8fRdfLiEhnRMBonlIbKrJWixoEmn6KCjKE9PElnrSDSXETGZfPb8ee+nQNTobXkCVvVLytp2o0obAsxl78Q=="],
+    "@oxfmt/binding-darwin-arm64": ["@oxfmt/binding-darwin-arm64@0.44.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-eWCLAIKAHfx88EqEP1Ga2yz7qVcqDU5lemn4xck+07bH182hDdprOHjbogyk0In1Djys3T0/pO2JepFnRJ41Mg=="],
 
-    "@oxfmt/binding-darwin-x64": ["@oxfmt/binding-darwin-x64@0.40.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-fzowhqbOE/NRy+AE5ob0+Y4X243WbWzDb00W+pKwD7d9tOqsAFbtWUwIyqqCoCLxj791m2xXIEeLH/3uz7zCCg=="],
+    "@oxfmt/binding-darwin-x64": ["@oxfmt/binding-darwin-x64@0.44.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-eHTBznHLM49++dwz07MblQ2cOXyIgeedmE3Wgy4ptUESj38/qYZyRi1MPwC9olQJWssMeY6WI3UZ7YmU5ggvyQ=="],
 
-    "@oxfmt/binding-freebsd-x64": ["@oxfmt/binding-freebsd-x64@0.40.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-agZ9ITaqdBjcerRRFEHB8s0OyVcQW8F9ZxsszjxzeSthQ4fcN2MuOtQFWec1ed8/lDa50jSLHVE2/xPmTgtCfQ=="],
+    "@oxfmt/binding-freebsd-x64": ["@oxfmt/binding-freebsd-x64@0.44.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-jLMmbj0u0Ft43QpkUVr/0v1ZfQCGWAvU+WznEHcN3wZC/q6ox7XeSJtk9P36CCpiDSUf3sGnzbIuG1KdEMEDJQ=="],
 
-    "@oxfmt/binding-linux-arm-gnueabihf": ["@oxfmt/binding-linux-arm-gnueabihf@0.40.0", "", { "os": "linux", "cpu": "arm" }, "sha512-ZM2oQ47p28TP1DVIp7HL1QoMUgqlBFHey0ksHct7tMXoU5BqjNvPWw7888azzMt25lnyPODVuye1wvNbvVUFOA=="],
+    "@oxfmt/binding-linux-arm-gnueabihf": ["@oxfmt/binding-linux-arm-gnueabihf@0.44.0", "", { "os": "linux", "cpu": "arm" }, "sha512-n+A/u/ByK1qV8FVGOwyaSpw5NPNl0qlZfgTBqHeGIqr8Qzq1tyWZ4lAaxPoe5mZqE3w88vn3+jZtMxriHPE7tg=="],
 
-    "@oxfmt/binding-linux-arm-musleabihf": ["@oxfmt/binding-linux-arm-musleabihf@0.40.0", "", { "os": "linux", "cpu": "arm" }, "sha512-RBFPAxRAIsMisKM47Oe6Lwdv6agZYLz02CUhVCD1sOv5ajAcRMrnwCFBPWwGXpazToW2mjnZxFos8TuFjTU15A=="],
+    "@oxfmt/binding-linux-arm-musleabihf": ["@oxfmt/binding-linux-arm-musleabihf@0.44.0", "", { "os": "linux", "cpu": "arm" }, "sha512-5eax+FkxyCqAi3Rw0mrZFr7+KTt/XweFsbALR+B5ljWBLBl8nHe4ADrUnb1gLEfQCJLl+Ca5FIVD4xEt95AwIw=="],
 
-    "@oxfmt/binding-linux-arm64-gnu": ["@oxfmt/binding-linux-arm64-gnu@0.40.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-Nb2XbQ+wV3W2jSIihXdPj7k83eOxeSgYP3N/SRXvQ6ZYPIk6Q86qEh5Gl/7OitX3bQoQrESqm1yMLvZV8/J7dA=="],
+    "@oxfmt/binding-linux-arm64-gnu": ["@oxfmt/binding-linux-arm64-gnu@0.44.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-58l8JaHxSGOmOMOG2CIrNsnkRJAj0YcHQCmvNACniOa/vd1iRHhlPajczegzS5jwMENlqgreyiTR9iNlke8qCw=="],
 
-    "@oxfmt/binding-linux-arm64-musl": ["@oxfmt/binding-linux-arm64-musl@0.40.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-tGmWhLD/0YMotCdfezlT6tC/MJG/wKpo4vnQ3Cq+4eBk/BwNv7EmkD0VkD5F/dYkT3b8FNU01X2e8vvJuWoM1w=="],
+    "@oxfmt/binding-linux-arm64-musl": ["@oxfmt/binding-linux-arm64-musl@0.44.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-AlObQIXyVRZ96LbtVljtFq0JqH5B92NU+BQeDFrXWBUWlCKAM0wF5GLfIhCLT5kQ3Sl+U0YjRJ7Alqj5hGQaCg=="],
 
-    "@oxfmt/binding-linux-ppc64-gnu": ["@oxfmt/binding-linux-ppc64-gnu@0.40.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-rVbFyM3e7YhkVnp0IVYjaSHfrBWcTRWb60LEcdNAJcE2mbhTpbqKufx0FrhWfoxOrW/+7UJonAOShoFFLigDqQ=="],
+    "@oxfmt/binding-linux-ppc64-gnu": ["@oxfmt/binding-linux-ppc64-gnu@0.44.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-YcFE8/q/BbrCiIiM5piwbkA6GwJc5QqhMQp2yDrqQ2fuVkZ7CInb1aIijZ/k8EXc72qXMSwKpVlBv1w/MsGO/A=="],
 
-    "@oxfmt/binding-linux-riscv64-gnu": ["@oxfmt/binding-linux-riscv64-gnu@0.40.0", "", { "os": "linux", "cpu": "none" }, "sha512-3ZqBw14JtWeEoLiioJcXSJz8RQyPE+3jLARnYM1HdPzZG4vk+Ua8CUupt2+d+vSAvMyaQBTN2dZK+kbBS/j5mA=="],
+    "@oxfmt/binding-linux-riscv64-gnu": ["@oxfmt/binding-linux-riscv64-gnu@0.44.0", "", { "os": "linux", "cpu": "none" }, "sha512-eOdzs6RqkRzuqNHUX5C8ISN5xfGh4xDww8OEd9YAmc3OWN8oAe5bmlIqQ+rrHLpv58/0BuU48bxkhnIGjA/ATQ=="],
 
-    "@oxfmt/binding-linux-riscv64-musl": ["@oxfmt/binding-linux-riscv64-musl@0.40.0", "", { "os": "linux", "cpu": "none" }, "sha512-JJ4PPSdcbGBjPvb+O7xYm2FmAsKCyuEMYhqatBAHMp/6TA6rVlf9Z/sYPa4/3Bommb+8nndm15SPFRHEPU5qFA=="],
+    "@oxfmt/binding-linux-riscv64-musl": ["@oxfmt/binding-linux-riscv64-musl@0.44.0", "", { "os": "linux", "cpu": "none" }, "sha512-YBgNTxntD/QvlFUfgvh8bEdwOhXiquX8gaofZJAwYa/Xp1S1DQrFVZEeck7GFktr24DztsSp8N8WtWCBwxs0Hw=="],
 
-    "@oxfmt/binding-linux-s390x-gnu": ["@oxfmt/binding-linux-s390x-gnu@0.40.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-Kp0zNJoX9Ik77wUya2tpBY3W9f40VUoMQLWVaob5SgCrblH/t2xr/9B2bWHfs0WCefuGmqXcB+t0Lq77sbBmZw=="],
+    "@oxfmt/binding-linux-s390x-gnu": ["@oxfmt/binding-linux-s390x-gnu@0.44.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-GLIh1R6WHWshl/i4QQDNgj0WtT25aRO4HNUWEoitxiywyRdhTFmFEYT2rXlcl9U6/26vhmOqG5cRlMLG3ocaIA=="],
 
-    "@oxfmt/binding-linux-x64-gnu": ["@oxfmt/binding-linux-x64-gnu@0.40.0", "", { "os": "linux", "cpu": "x64" }, "sha512-7YTCNzleWTaQTqNGUNQ66qVjpoV6DjbCOea+RnpMBly2bpzrI/uu7Rr+2zcgRfNxyjXaFTVQKaRKjqVdeUfeVA=="],
+    "@oxfmt/binding-linux-x64-gnu": ["@oxfmt/binding-linux-x64-gnu@0.44.0", "", { "os": "linux", "cpu": "x64" }, "sha512-gZOpgTlOsLcLfAF9qgpTr7FIIFSKnQN3hDf/0JvQ4CIwMY7h+eilNjxq/CorqvYcEOu+LRt1W4ZS7KccEHLOdA=="],
 
-    "@oxfmt/binding-linux-x64-musl": ["@oxfmt/binding-linux-x64-musl@0.40.0", "", { "os": "linux", "cpu": "x64" }, "sha512-hWnSzJ0oegeOwfOEeejYXfBqmnRGHusgtHfCPzmvJvHTwy1s3Neo59UKc1CmpE3zxvrCzJoVHos0rr97GHMNPw=="],
+    "@oxfmt/binding-linux-x64-musl": ["@oxfmt/binding-linux-x64-musl@0.44.0", "", { "os": "linux", "cpu": "x64" }, "sha512-1CyS9JTB+pCUFYFI6pkQGGZaT/AY5gnhHVrQQLhFba6idP9AzVYm1xbdWfywoldTYvjxQJV6x4SuduCIfP3W+A=="],
 
-    "@oxfmt/binding-openharmony-arm64": ["@oxfmt/binding-openharmony-arm64@0.40.0", "", { "os": "none", "cpu": "arm64" }, "sha512-28sJC1lR4qtBJGzSRRbPnSW3GxU2+4YyQFE6rCmsUYqZ5XYH8jg0/w+CvEzQ8TuAQz5zLkcA25nFQGwoU0PT3Q=="],
+    "@oxfmt/binding-openharmony-arm64": ["@oxfmt/binding-openharmony-arm64@0.44.0", "", { "os": "none", "cpu": "arm64" }, "sha512-bmEv70Ak6jLr1xotCbF5TxIKjsmQaiX+jFRtnGtfA03tJPf6VG3cKh96S21boAt3JZc+Vjx8PYcDuLj39vM2Pw=="],
 
-    "@oxfmt/binding-win32-arm64-msvc": ["@oxfmt/binding-win32-arm64-msvc@0.40.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-cDkRnyT0dqwF5oIX1Cv59HKCeZQFbWWdUpXa3uvnHFT2iwYSSZspkhgjXjU6iDp5pFPaAEAe9FIbMoTgkTmKPg=="],
+    "@oxfmt/binding-win32-arm64-msvc": ["@oxfmt/binding-win32-arm64-msvc@0.44.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-yWzB+oCpSnP/dmw85eFLAT5o35Ve5pkGS2uF/UCISpIwDqf1xa7OpmtomiqY/Vzg8VyvMbuf6vroF2khF/+1Vg=="],
 
-    "@oxfmt/binding-win32-ia32-msvc": ["@oxfmt/binding-win32-ia32-msvc@0.40.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-7rPemBJjqm5Gkv6ZRCPvK8lE6AqQ/2z31DRdWazyx2ZvaSgL7QGofHXHNouRpPvNsT9yxRNQJgigsWkc+0qg4w=="],
+    "@oxfmt/binding-win32-ia32-msvc": ["@oxfmt/binding-win32-ia32-msvc@0.44.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-TcWpo18xEIE3AmIG2kpr3kz5IEhQgnx0lazl2+8L+3eTopOAUevQcmlr4nhguImNWz0OMeOZrYZOhJNCf16nlQ=="],
 
-    "@oxfmt/binding-win32-x64-msvc": ["@oxfmt/binding-win32-x64-msvc@0.40.0", "", { "os": "win32", "cpu": "x64" }, "sha512-/Zmj0yTYSvmha6TG1QnoLqVT7ZMRDqXvFXXBQpIjteEwx9qvUYMBH2xbiOFhDeMUJkGwC3D6fdKsFtaqUvkwNA=="],
+    "@oxfmt/binding-win32-x64-msvc": ["@oxfmt/binding-win32-x64-msvc@0.44.0", "", { "os": "win32", "cpu": "x64" }, "sha512-oj8aLkPJZppIM4CMQNsyir9ybM1Xw/CfGPTSsTnzpVGyljgfbdP0EVUlURiGM0BDrmw5psQ6ArmGCcUY/yABaQ=="],
 
-    "@oxlint-tsgolint/darwin-arm64": ["@oxlint-tsgolint/darwin-arm64@0.16.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-WQt5lGwRPJBw7q2KNR0mSPDAaMmZmVvDlEEti96xLO7ONhyomQc6fBZxxwZ4qTFedjJnrHX94sFelZ4OKzS7UQ=="],
+    "@oxlint-tsgolint/darwin-arm64": ["@oxlint-tsgolint/darwin-arm64@0.20.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-KKQcIHZHMxqpHUA1VXIbOG6chNCFkUWbQy6M+AFVtPKkA/3xAeJkJ3njoV66bfzwPHRcWQO+kcj5XqtbkjakoA=="],
 
-    "@oxlint-tsgolint/darwin-x64": ["@oxlint-tsgolint/darwin-x64@0.16.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-VJo29XOzdkalvCTiE2v6FU3qZlgHaM8x8hUEVJGPU2i5W+FlocPpmn00+Ld2n7Q0pqIjyD5EyvZ5UmoIEJMfqg=="],
+    "@oxlint-tsgolint/darwin-x64": ["@oxlint-tsgolint/darwin-x64@0.20.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-7HeVMuclGfG+NLZi2ybY0T4fMI7/XxO/208rJk+zEIloKkVnlh11Wd241JMGwgNFXn+MLJbOqOfojDb2Dt4L1g=="],
 
-    "@oxlint-tsgolint/linux-arm64": ["@oxlint-tsgolint/linux-arm64@0.16.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-MPfqRt1+XRHv9oHomcBMQ3KpTE+CSkZz14wUxDQoqTNdUlV0HWdzwIE9q65I3D9YyxEnqpM7j4qtDQ3apqVvbQ=="],
+    "@oxlint-tsgolint/linux-arm64": ["@oxlint-tsgolint/linux-arm64@0.20.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-zxhUwz+WSxE6oWlZLK2z2ps9yC6ebmgoYmjAl0Oa48+GqkZ56NVgo+wb8DURNv6xrggzHStQxqQxe3mK51HZag=="],
 
-    "@oxlint-tsgolint/linux-x64": ["@oxlint-tsgolint/linux-x64@0.16.0", "", { "os": "linux", "cpu": "x64" }, "sha512-XQSwVUsnwLokMhe1TD6IjgvW5WMTPzOGGkdFDtXWQmlN2YeTw94s/NN0KgDrn2agM1WIgAenEkvnm0u7NgwEyw=="],
+    "@oxlint-tsgolint/linux-x64": ["@oxlint-tsgolint/linux-x64@0.20.0", "", { "os": "linux", "cpu": "x64" }, "sha512-/1l6FnahC9im8PK+Ekkx/V3yetO/PzZnJegE2FXcv/iXEhbeVxP/ouiTYcUQu9shT1FWJCSNti1VJHH+21Y1dg=="],
 
-    "@oxlint-tsgolint/win32-arm64": ["@oxlint-tsgolint/win32-arm64@0.16.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-EWdlspQiiFGsP2AiCYdhg5dTYyAlj6y1nRyNI2dQWq4Q/LITFHiSRVPe+7m7K7lcsZCEz2icN/bCeSkZaORqIg=="],
+    "@oxlint-tsgolint/win32-arm64": ["@oxlint-tsgolint/win32-arm64@0.20.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-oPZ5Yz8sVdo7P/5q+i3IKeix31eFZ55JAPa1+RGPoe9PoaYVsdMvR6Jvib6YtrqoJnFPlg3fjEjlEPL8VBKYJA=="],
 
-    "@oxlint-tsgolint/win32-x64": ["@oxlint-tsgolint/win32-x64@0.16.0", "", { "os": "win32", "cpu": "x64" }, "sha512-1ufk8cgktXJuJZHKF63zCHAkaLMwZrEXnZ89H2y6NO85PtOXqu4zbdNl0VBpPP3fCUuUBu9RvNqMFiv0VsbXWA=="],
+    "@oxlint-tsgolint/win32-x64": ["@oxlint-tsgolint/win32-x64@0.20.0", "", { "os": "win32", "cpu": "x64" }, "sha512-4stx8RHj3SP9vQyRF/yZbz5igtPvYMEUR8CUoha4BVNZihi39DpCR8qkU7lpjB5Ga1DRMo2pHaA4bdTOMaY4mw=="],
 
-    "@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.55.0", "", { "os": "android", "cpu": "arm" }, "sha512-NhvgAhncTSOhRahQSCnkK/4YIGPjTmhPurQQ2dwt2IvwCMTvZRW5vF2K10UBOxFve4GZDMw6LtXZdC2qeuYIVQ=="],
+    "@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.59.0", "", { "os": "android", "cpu": "arm" }, "sha512-etYDw/UaEv936AQUd/CRMBVd+e+XuuU6wC+VzOv1STvsTyZenLChepLWqLtnyTTp4YMlM22ypzogDDwqYxv5cg=="],
 
-    "@oxlint/binding-android-arm64": ["@oxlint/binding-android-arm64@1.55.0", "", { "os": "android", "cpu": "arm64" }, "sha512-P9iWRh+Ugqhg+D7rkc7boHX8o3H2h7YPcZHQIgvVBgnua5tk4LR2L+IBlreZs58/95cd2x3/004p5VsQM9z4SA=="],
+    "@oxlint/binding-android-arm64": ["@oxlint/binding-android-arm64@1.59.0", "", { "os": "android", "cpu": "arm64" }, "sha512-TgLc7XVLKH2a4h8j3vn1MDjfK33i9MY60f/bKhRGWyVzbk5LCZ4X01VZG7iHrMmi5vYbAp8//Ponigx03CLsdw=="],
 
-    "@oxlint/binding-darwin-arm64": ["@oxlint/binding-darwin-arm64@1.55.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-esakkJIt7WFAhT30P/Qzn96ehFpzdZ1mNuzpOb8SCW7lI4oB8VsyQnkSHREM671jfpuBb/o2ppzBCx5l0jpgMA=="],
+    "@oxlint/binding-darwin-arm64": ["@oxlint/binding-darwin-arm64@1.59.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-DXyFPf5ZKldMLloRHx/B9fsxsiTQomaw7cmEW3YIJko2HgCh+GUhp9gGYwHrqlLJPsEe3dYj9JebjX92D3j3AA=="],
 
-    "@oxlint/binding-darwin-x64": ["@oxlint/binding-darwin-x64@1.55.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-xDMFRCCAEK9fOH6As2z8ELsC+VDGSFRHwIKVSilw+xhgLwTDFu37rtmRbmUlx8rRGS6cWKQPTc47AVxAZEVVPQ=="],
+    "@oxlint/binding-darwin-x64": ["@oxlint/binding-darwin-x64@1.59.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-LgvrsdgVLX1qWqIEmNsSmMXJhpAWdtUQ0M+oR0CySwi+9IHWyOGuIL8w8+u/kbZNMyZr4WUyYB5i0+D+AKgkLg=="],
 
-    "@oxlint/binding-freebsd-x64": ["@oxlint/binding-freebsd-x64@1.55.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-mYZqnwUD7ALCRxGenyLd1uuG+rHCL+OTT6S8FcAbVm/ZT2AZMGjvibp3F6k1SKOb2aeqFATmwRykrE41Q0GWVw=="],
+    "@oxlint/binding-freebsd-x64": ["@oxlint/binding-freebsd-x64@1.59.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-bOJhqX/ny4hrFuTPlyk8foSRx/vLRpxJh0jOOKN2NWW6FScXHPAA5rQbrwdQPcgGB5V8Ua51RS03fke8ssBcug=="],
 
-    "@oxlint/binding-linux-arm-gnueabihf": ["@oxlint/binding-linux-arm-gnueabihf@1.55.0", "", { "os": "linux", "cpu": "arm" }, "sha512-LcX6RYcF9vL9ESGwJW3yyIZ/d/ouzdOKXxCdey1q0XJOW1asrHsIg5MmyKdEBR4plQx+shvYeQne7AzW5f3T1w=="],
+    "@oxlint/binding-linux-arm-gnueabihf": ["@oxlint/binding-linux-arm-gnueabihf@1.59.0", "", { "os": "linux", "cpu": "arm" }, "sha512-vVUXxYMF9trXCsz4m9H6U0IjehosVHxBzVgJUxly1uz4W1PdDyicaBnpC0KRXsHYretLVe+uS9pJy8iM57Kujw=="],
 
-    "@oxlint/binding-linux-arm-musleabihf": ["@oxlint/binding-linux-arm-musleabihf@1.55.0", "", { "os": "linux", "cpu": "arm" }, "sha512-C+8GS1rPtK+dI7mJFkqoRBkDuqbrNihnyYQsJPS9ez+8zF9JzfvU19lawqt4l/Y23o5uQswE/DORa8aiXUih3w=="],
+    "@oxlint/binding-linux-arm-musleabihf": ["@oxlint/binding-linux-arm-musleabihf@1.59.0", "", { "os": "linux", "cpu": "arm" }, "sha512-TULQW8YBPGRWg5yZpFPL54HLOnJ3/HiX6VenDPi6YfxB/jlItwSMFh3/hCeSNbh+DAMaE1Py0j5MOaivHkI/9Q=="],
 
-    "@oxlint/binding-linux-arm64-gnu": ["@oxlint/binding-linux-arm64-gnu@1.55.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-ErLE4XbmcCopA4/CIDiH6J1IAaDOMnf/KSx/aFObs4/OjAAM3sFKWGZ57pNOMxhhyBdcmcXwYymph9GwcpcqgQ=="],
+    "@oxlint/binding-linux-arm64-gnu": ["@oxlint/binding-linux-arm64-gnu@1.59.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-Gt54Y4eqSgYJ90xipm24xeyaPV854706o/kiT8oZvUt3VDY7qqxdqyGqchMaujd87ib+/MXvnl9WkK8Cc1BExg=="],
 
-    "@oxlint/binding-linux-arm64-musl": ["@oxlint/binding-linux-arm64-musl@1.55.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-/kp65avi6zZfqEng56TTuhiy3P/3pgklKIdf38yvYeJ9/PgEeRA2A2AqKAKbZBNAqUzrzHhz9jF6j/PZvhJzTQ=="],
+    "@oxlint/binding-linux-arm64-musl": ["@oxlint/binding-linux-arm64-musl@1.59.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-3CtsKp7NFB3OfqQzbuAecrY7GIZeiv7AD+xutU4tefVQzlfmTI7/ygWLrvkzsDEjTlMq41rYHxgsn6Yh8tybmA=="],
 
-    "@oxlint/binding-linux-ppc64-gnu": ["@oxlint/binding-linux-ppc64-gnu@1.55.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-A6pTdXwcEEwL/nmz0eUJ6WxmxcoIS+97GbH96gikAyre3s5deC7sts38ZVVowjS2QQFuSWkpA4ZmQC0jZSNvJQ=="],
+    "@oxlint/binding-linux-ppc64-gnu": ["@oxlint/binding-linux-ppc64-gnu@1.59.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-K0diOpT3ncDmOfl9I1HuvpEsAuTxkts0VYwIv/w6Xiy9CdwyPBVX88Ga9l8VlGgMrwBMnSY4xIvVlVY/fkQk7Q=="],
 
-    "@oxlint/binding-linux-riscv64-gnu": ["@oxlint/binding-linux-riscv64-gnu@1.55.0", "", { "os": "linux", "cpu": "none" }, "sha512-clj0lnIN+V52G9tdtZl0LbdTSurnZ1NZj92Je5X4lC7gP5jiCSW+Y/oiDiSauBAD4wrHt2S7nN3pA0zfKYK/6Q=="],
+    "@oxlint/binding-linux-riscv64-gnu": ["@oxlint/binding-linux-riscv64-gnu@1.59.0", "", { "os": "linux", "cpu": "none" }, "sha512-xAU7+QDU6kTJJ7mJLOGgo7oOjtAtkKyFZ0Yjdb5cEo3DiCCPFLvyr08rWiQh6evZ7RiUTf+o65NY/bqttzJiQQ=="],
 
-    "@oxlint/binding-linux-riscv64-musl": ["@oxlint/binding-linux-riscv64-musl@1.55.0", "", { "os": "linux", "cpu": "none" }, "sha512-NNu08pllN5x/O94/sgR3DA8lbrGBnTHsINZZR0hcav1sj79ksTiKKm1mRzvZvacwQ0hUnGinFo+JO75ok2PxYg=="],
+    "@oxlint/binding-linux-riscv64-musl": ["@oxlint/binding-linux-riscv64-musl@1.59.0", "", { "os": "linux", "cpu": "none" }, "sha512-KUmZmKlTTyauOnvUNVxK7G40sSSx0+w5l1UhaGsC6KPpOYHenx2oqJTnabmpLJicok7IC+3Y6fXAUOMyexaeJQ=="],
 
-    "@oxlint/binding-linux-s390x-gnu": ["@oxlint/binding-linux-s390x-gnu@1.55.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-BvfQz3PRlWZRoEZ17dZCqgQsMRdpzGZomJkVATwCIGhHVVeHJMQdmdXPSjcT1DCNUrOjXnVyj1RGDj5+/Je2+Q=="],
+    "@oxlint/binding-linux-s390x-gnu": ["@oxlint/binding-linux-s390x-gnu@1.59.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-4usRxC8gS0PGdkHnRmwJt/4zrQNZyk6vL0trCxwZSsAKM+OxhB8nKiR+mhjdBbl8lbMh2gc3bZpNN/ik8c4c2A=="],
 
-    "@oxlint/binding-linux-x64-gnu": ["@oxlint/binding-linux-x64-gnu@1.55.0", "", { "os": "linux", "cpu": "x64" }, "sha512-ngSOoFCSBMKVQd24H8zkbcBNc7EHhjnF1sv3mC9NNXQ/4rRjI/4Dj9+9XoDZeFEkF1SX1COSBXF1b2Pr9rqdEw=="],
+    "@oxlint/binding-linux-x64-gnu": ["@oxlint/binding-linux-x64-gnu@1.59.0", "", { "os": "linux", "cpu": "x64" }, "sha512-s/rNE2gDmbwAOOP493xk2X7M8LZfI1LJFSSW1+yanz3vuQCFPiHkx4GY+O1HuLUDtkzGlhtMrIcxxzyYLv308w=="],
 
-    "@oxlint/binding-linux-x64-musl": ["@oxlint/binding-linux-x64-musl@1.55.0", "", { "os": "linux", "cpu": "x64" }, "sha512-BDpP7W8GlaG7BR6QjGZAleYzxoyKc/D24spZIF2mB3XsfALQJJT/OBmP8YpeTb1rveFSBHzl8T7l0aqwkWNdGA=="],
+    "@oxlint/binding-linux-x64-musl": ["@oxlint/binding-linux-x64-musl@1.59.0", "", { "os": "linux", "cpu": "x64" }, "sha512-+yYj1udJa2UvvIUmEm0IcKgc0UlPMgz0nsSTvkPL2y6n0uU5LgIHSwVu4AHhrve6j9BpVSoRksnz8c9QcvITJA=="],
 
-    "@oxlint/binding-openharmony-arm64": ["@oxlint/binding-openharmony-arm64@1.55.0", "", { "os": "none", "cpu": "arm64" }, "sha512-PS6GFvmde/pc3fCA2Srt51glr8Lcxhpf6WIBFfLphndjRrD34NEcses4TSxQrEcxYo6qVywGfylM0ZhSCF2gGA=="],
+    "@oxlint/binding-openharmony-arm64": ["@oxlint/binding-openharmony-arm64@1.59.0", "", { "os": "none", "cpu": "arm64" }, "sha512-bUplUb48LYsB3hHlQXP2ZMOenpieWoOyppLAnnAhuPag3MGPnt+7caxE3w/Vl9wpQsTA3gzLntQi9rxWrs7Xqg=="],
 
-    "@oxlint/binding-win32-arm64-msvc": ["@oxlint/binding-win32-arm64-msvc@1.55.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-P6JcLJGs/q1UOvDLzN8otd9JsH4tsuuPDv+p7aHqHM3PrKmYdmUvkNj4K327PTd35AYcznOCN+l4ZOaq76QzSw=="],
+    "@oxlint/binding-win32-arm64-msvc": ["@oxlint/binding-win32-arm64-msvc@1.59.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-/HLsLuz42rWl7h7ePdmMTpHm2HIDmPtcEMYgm5BBEHiEiuNOrzMaUpd2z7UnNni5LGN9obJy2YoAYBLXQwazrA=="],
 
-    "@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.55.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-gzkk4zE2zsE+WmRxFOiAZHpCpUNDFytEakqNXoNHW+PnYEOTPKDdW6nrzgSeTbGKVPXNAKQnRnMgrh7+n3Xueg=="],
+    "@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.59.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-rUPy+JnanpPwV/aJCPnxAD1fW50+XPI0VkWr7f0vEbqcdsS8NpB24Rw6RsS7SdpFv8Dw+8ugCwao5nCFbqOUSg=="],
 
-    "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.55.0", "", { "os": "win32", "cpu": "x64" }, "sha512-ZFALNow2/og75gvYzNP7qe+rREQ5xunktwA+lgykoozHZ6hw9bqg4fn5j2UvG4gIn1FXqrZHkOAXuPf5+GOYTQ=="],
+    "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.59.0", "", { "os": "win32", "cpu": "x64" }, "sha512-xkE7puteDS/vUyRngLXW0t8WgdWoS/tfxXjhP/P7SMqPDx+hs44SpssO3h3qmTqECYEuXBUPzcAw5257Ka+ofA=="],
 
     "@parcel/watcher": ["@parcel/watcher@2.5.1", "", { "dependencies": { "detect-libc": "^1.0.3", "is-glob": "^4.0.3", "micromatch": "^4.0.5", "node-addon-api": "^7.0.0" }, "optionalDependencies": { "@parcel/watcher-android-arm64": "2.5.1", "@parcel/watcher-darwin-arm64": "2.5.1", "@parcel/watcher-darwin-x64": "2.5.1", "@parcel/watcher-freebsd-x64": "2.5.1", "@parcel/watcher-linux-arm-glibc": "2.5.1", "@parcel/watcher-linux-arm-musl": "2.5.1", "@parcel/watcher-linux-arm64-glibc": "2.5.1", "@parcel/watcher-linux-arm64-musl": "2.5.1", "@parcel/watcher-linux-x64-glibc": "2.5.1", "@parcel/watcher-linux-x64-musl": "2.5.1", "@parcel/watcher-win32-arm64": "2.5.1", "@parcel/watcher-win32-ia32": "2.5.1", "@parcel/watcher-win32-x64": "2.5.1" } }, "sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg=="],
 
@@ -3015,11 +3015,11 @@
 
     "oxc-walker": ["oxc-walker@0.7.0", "", { "dependencies": { "magic-regexp": "^0.10.0" }, "peerDependencies": { "oxc-parser": ">=0.98.0" } }, "sha512-54B4KUhrzbzc4sKvKwVYm7E2PgeROpGba0/2nlNZMqfDyca+yOor5IMb4WLGBatGDT0nkzYdYuzylg7n3YfB7A=="],
 
-    "oxfmt": ["oxfmt@0.40.0", "", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.40.0", "@oxfmt/binding-android-arm64": "0.40.0", "@oxfmt/binding-darwin-arm64": "0.40.0", "@oxfmt/binding-darwin-x64": "0.40.0", "@oxfmt/binding-freebsd-x64": "0.40.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.40.0", "@oxfmt/binding-linux-arm-musleabihf": "0.40.0", "@oxfmt/binding-linux-arm64-gnu": "0.40.0", "@oxfmt/binding-linux-arm64-musl": "0.40.0", "@oxfmt/binding-linux-ppc64-gnu": "0.40.0", "@oxfmt/binding-linux-riscv64-gnu": "0.40.0", "@oxfmt/binding-linux-riscv64-musl": "0.40.0", "@oxfmt/binding-linux-s390x-gnu": "0.40.0", "@oxfmt/binding-linux-x64-gnu": "0.40.0", "@oxfmt/binding-linux-x64-musl": "0.40.0", "@oxfmt/binding-openharmony-arm64": "0.40.0", "@oxfmt/binding-win32-arm64-msvc": "0.40.0", "@oxfmt/binding-win32-ia32-msvc": "0.40.0", "@oxfmt/binding-win32-x64-msvc": "0.40.0" }, "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-g0C3I7xUj4b4DcagevM9kgH6+pUHytikxUcn3/VUkvzTNaaXBeyZqb7IBsHwojeXm4mTBEC/aBjBTMVUkZwWUQ=="],
+    "oxfmt": ["oxfmt@0.44.0", "", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.44.0", "@oxfmt/binding-android-arm64": "0.44.0", "@oxfmt/binding-darwin-arm64": "0.44.0", "@oxfmt/binding-darwin-x64": "0.44.0", "@oxfmt/binding-freebsd-x64": "0.44.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.44.0", "@oxfmt/binding-linux-arm-musleabihf": "0.44.0", "@oxfmt/binding-linux-arm64-gnu": "0.44.0", "@oxfmt/binding-linux-arm64-musl": "0.44.0", "@oxfmt/binding-linux-ppc64-gnu": "0.44.0", "@oxfmt/binding-linux-riscv64-gnu": "0.44.0", "@oxfmt/binding-linux-riscv64-musl": "0.44.0", "@oxfmt/binding-linux-s390x-gnu": "0.44.0", "@oxfmt/binding-linux-x64-gnu": "0.44.0", "@oxfmt/binding-linux-x64-musl": "0.44.0", "@oxfmt/binding-openharmony-arm64": "0.44.0", "@oxfmt/binding-win32-arm64-msvc": "0.44.0", "@oxfmt/binding-win32-ia32-msvc": "0.44.0", "@oxfmt/binding-win32-x64-msvc": "0.44.0" }, "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-lnncqvHewyRvaqdrnntVIrZV2tEddz8lbvPsQzG/zlkfvgZkwy0HP1p/2u1aCDToeg1jb9zBpbJdfkV73Itw+w=="],
 
-    "oxlint": ["oxlint@1.55.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.55.0", "@oxlint/binding-android-arm64": "1.55.0", "@oxlint/binding-darwin-arm64": "1.55.0", "@oxlint/binding-darwin-x64": "1.55.0", "@oxlint/binding-freebsd-x64": "1.55.0", "@oxlint/binding-linux-arm-gnueabihf": "1.55.0", "@oxlint/binding-linux-arm-musleabihf": "1.55.0", "@oxlint/binding-linux-arm64-gnu": "1.55.0", "@oxlint/binding-linux-arm64-musl": "1.55.0", "@oxlint/binding-linux-ppc64-gnu": "1.55.0", "@oxlint/binding-linux-riscv64-gnu": "1.55.0", "@oxlint/binding-linux-riscv64-musl": "1.55.0", "@oxlint/binding-linux-s390x-gnu": "1.55.0", "@oxlint/binding-linux-x64-gnu": "1.55.0", "@oxlint/binding-linux-x64-musl": "1.55.0", "@oxlint/binding-openharmony-arm64": "1.55.0", "@oxlint/binding-win32-arm64-msvc": "1.55.0", "@oxlint/binding-win32-ia32-msvc": "1.55.0", "@oxlint/binding-win32-x64-msvc": "1.55.0" }, "peerDependencies": { "oxlint-tsgolint": ">=0.15.0" }, "optionalPeers": ["oxlint-tsgolint"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-T+FjepiyWpaZMhekqRpH8Z3I4vNM610p6w+Vjfqgj5TZUxHXl7N8N5IPvmOU8U4XdTRxqtNNTh9Y4hLtr7yvFg=="],
+    "oxlint": ["oxlint@1.59.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.59.0", "@oxlint/binding-android-arm64": "1.59.0", "@oxlint/binding-darwin-arm64": "1.59.0", "@oxlint/binding-darwin-x64": "1.59.0", "@oxlint/binding-freebsd-x64": "1.59.0", "@oxlint/binding-linux-arm-gnueabihf": "1.59.0", "@oxlint/binding-linux-arm-musleabihf": "1.59.0", "@oxlint/binding-linux-arm64-gnu": "1.59.0", "@oxlint/binding-linux-arm64-musl": "1.59.0", "@oxlint/binding-linux-ppc64-gnu": "1.59.0", "@oxlint/binding-linux-riscv64-gnu": "1.59.0", "@oxlint/binding-linux-riscv64-musl": "1.59.0", "@oxlint/binding-linux-s390x-gnu": "1.59.0", "@oxlint/binding-linux-x64-gnu": "1.59.0", "@oxlint/binding-linux-x64-musl": "1.59.0", "@oxlint/binding-openharmony-arm64": "1.59.0", "@oxlint/binding-win32-arm64-msvc": "1.59.0", "@oxlint/binding-win32-ia32-msvc": "1.59.0", "@oxlint/binding-win32-x64-msvc": "1.59.0" }, "peerDependencies": { "oxlint-tsgolint": ">=0.18.0" }, "optionalPeers": ["oxlint-tsgolint"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-0xBLeGGjP4vD9pygRo8iuOkOzEU1MqOnfiOl7KYezL/QvWL8NUg6n03zXc7ZVqltiOpUxBk2zgHI3PnRIEdAvw=="],
 
-    "oxlint-tsgolint": ["oxlint-tsgolint@0.16.0", "", { "optionalDependencies": { "@oxlint-tsgolint/darwin-arm64": "0.16.0", "@oxlint-tsgolint/darwin-x64": "0.16.0", "@oxlint-tsgolint/linux-arm64": "0.16.0", "@oxlint-tsgolint/linux-x64": "0.16.0", "@oxlint-tsgolint/win32-arm64": "0.16.0", "@oxlint-tsgolint/win32-x64": "0.16.0" }, "bin": { "tsgolint": "bin/tsgolint.js" } }, "sha512-4RuJK2jP08XwqtUu+5yhCbxEauCm6tv2MFHKEMsjbosK2+vy5us82oI3VLuHwbNyZG7ekZA26U2LLHnGR4frIA=="],
+    "oxlint-tsgolint": ["oxlint-tsgolint@0.20.0", "", { "optionalDependencies": { "@oxlint-tsgolint/darwin-arm64": "0.20.0", "@oxlint-tsgolint/darwin-x64": "0.20.0", "@oxlint-tsgolint/linux-arm64": "0.20.0", "@oxlint-tsgolint/linux-x64": "0.20.0", "@oxlint-tsgolint/win32-arm64": "0.20.0", "@oxlint-tsgolint/win32-x64": "0.20.0" }, "bin": { "tsgolint": "bin/tsgolint.js" } }, "sha512-/Uc9TQyN1l8w9QNvXtVHYtz+SzDJHKpb5X0UnHodl0BVzijUPk0LPlDOHAvogd1UI+iy9ZSF6gQxEqfzUxCULQ=="],
 
     "p-event": ["p-event@6.0.1", "", { "dependencies": { "p-timeout": "^6.1.2" } }, "sha512-Q6Bekk5wpzW5qIyUP4gdMEujObYstZl6DMMOSenwBvV0BlE5LkDwkjs5yHbZmdCEq2o4RJx4tE1vwxFVf2FG1w=="],
 

--- a/frontend/dashboard/codegen-plugins/zod.ts
+++ b/frontend/dashboard/codegen-plugins/zod.ts
@@ -1,31 +1,30 @@
-import type { CodegenPlugin, Types } from '@graphql-codegen/plugin-helpers'
-import type { DirectiveNode, GraphQLSchema, InputObjectTypeDefinitionNode } from 'graphql'
-import { print } from 'graphql'
+import type { Types } from '@graphql-codegen/plugin-helpers';
+import type { DirectiveNode, GraphQLSchema, InputObjectTypeDefinitionNode } from 'graphql';
 
 /**
  * Plugin configuration
  */
 export interface ZodValidatorPluginConfig {
 	/** Enable debug logging */
-	debug?: boolean
+	debug?: boolean;
 	/** Custom import path for zod, e.g. '@/lib/zod' */
-	importFrom?: string
+	importFrom?: string;
 }
 
 export const plugin: (
 	schema: GraphQLSchema,
 	_documents: Types.DocumentFile[],
-	config: ZodValidatorPluginConfig
+	config: ZodValidatorPluginConfig,
 ) => {
-	prepend: any[]
-	content: string
+	prepend: any[];
+	content: string;
 } = (schema: GraphQLSchema, _documents: Types.DocumentFile[], config: ZodValidatorPluginConfig) => {
-	const { debug = false, importFrom } = config
+	const { debug = false, importFrom } = config;
 	const header = `
 /**
 	Code generated. DO NOT EDIT.
-*/`
-	const zodImport = importFrom ? `import { z } from '${importFrom}';` : `import { z } from 'zod';`
+*/`;
+	const zodImport = importFrom ? `import { z } from '${importFrom}';` : `import { z } from 'zod';`;
 
 	// --------------------------------------------------------------------- //
 	// 1. Find all InputObjectTypeDefinition nodes
@@ -33,46 +32,46 @@ export const plugin: (
 	const inputTypes = Object.values(schema.getTypeMap())
 		.map((type) => type.astNode)
 		.filter(
-			(node): node is InputObjectTypeDefinitionNode => node?.kind === 'InputObjectTypeDefinition'
-		)
+			(node): node is InputObjectTypeDefinitionNode => node?.kind === 'InputObjectTypeDefinition',
+		);
 
 	if (inputTypes.length === 0) {
-		return { prepend: [], content: '// No input types found in schema.\n' }
+		return { prepend: [], content: '// No input types found in schema.\n' };
 	}
 
 	// --------------------------------------------------------------------- //
 	// 2. Generate Zod schema for each input
 	// --------------------------------------------------------------------- //
-	const generated = inputTypes.map((input) => generateZodSchema(input, schema))
+	const generated = inputTypes.map((input) => generateZodSchema(input, schema));
 
-	const content = `${header}\n\n${zodImport}\n\n${generated.join('\n\n')}\n`
+	const content = `${header}\n\n${zodImport}\n\n${generated.join('\n\n')}\n`;
 
 	if (debug) {
 		console.log(
 			'[zod-validator-plugin] Generated schemas for:',
-			inputTypes.map((t) => t.name.value).join(', ')
-		)
+			inputTypes.map((t) => t.name.value).join(', '),
+		);
 	}
 
-	return { prepend: [], content }
-}
+	return { prepend: [], content };
+};
 
 /* --------------------------------------------------------------------- */
 /* Helper: generate Zod object schema for a single input type            */
 /* --------------------------------------------------------------------- */
 function generateZodSchema(input: InputObjectTypeDefinitionNode, schema: GraphQLSchema): string {
-	const name = input.name.value
-	const fields = input.fields ?? []
+	const name = input.name.value;
+	const fields = input.fields ?? [];
 
 	const zodFields = fields.map((field) => {
-		const fieldName = field.name.value
+		const fieldName = field.name.value;
 
 		// ---- optionality ------------------------------------------------- //
-		const isNonNull = field.type.kind === 'NonNullType'
-		const hasQuestionMark = field.type.kind === 'NamedType' && field.type.name.value.endsWith('?')
-		const rawConstraint = getValidateConstraint(field)
-		const hasOmitempty = rawConstraint?.includes('omitempty') ?? false
-		const isOptional = !isNonNull || hasQuestionMark || hasOmitempty
+		const isNonNull = field.type.kind === 'NonNullType';
+		const hasQuestionMark = field.type.kind === 'NamedType' && field.type.name.value.endsWith('?');
+		const rawConstraint = getValidateConstraint(field);
+		const hasOmitempty = rawConstraint?.includes('omitempty') ?? false;
+		const isOptional = !isNonNull || hasQuestionMark || hasOmitempty;
 
 		// ---- constraints ------------------------------------------------- //
 		const constraints = rawConstraint
@@ -80,107 +79,107 @@ function generateZodSchema(input: InputObjectTypeDefinitionNode, schema: GraphQL
 					.split(',')
 					.map((s) => s.trim())
 					.filter((s) => s !== 'omitempty')
-			: []
+			: [];
 
-		const hasDive = constraints.includes('dive')
+		const hasDive = constraints.includes('dive');
 		const isList =
 			field.type.kind === 'ListType' ||
-			(field.type.kind === 'NonNullType' && field.type.type.kind === 'ListType')
+			(field.type.kind === 'NonNullType' && field.type.type.kind === 'ListType');
 
 		// Length-related tags
-		const lengthTags = new Set(['min', 'max', 'len', 'lte', 'gte'])
+		const lengthTags = new Set(['min', 'max', 'len', 'lte', 'gte']);
 		const lengthParts = constraints.filter((part) => {
-			const [tag] = part.split('=')
-			return lengthTags.has(tag!)
-		})
+			const [tag] = part.split('=');
+			return lengthTags.has(tag!);
+		});
 
 		// Parts to apply to outer validator
-		const partsToApply = isList && hasDive ? lengthParts : constraints.filter((c) => c !== 'dive')
+		const partsToApply = isList && hasDive ? lengthParts : constraints.filter((c) => c !== 'dive');
 
 		// ---- base validator ---------------------------------------------- //
-		let validator: string
-		let inner: string | null = null
+		let validator: string;
+		let inner: string | null = null;
 		if (isList) {
-			const innerNode = field.type.kind === 'ListType' ? field.type.type : field.type.type
-			inner = getBaseZodType(innerNode, schema)
+			const innerNode = field.type.kind === 'ListType' ? field.type.type : field.type.type;
+			inner = getBaseZodType(innerNode, schema);
 			if (hasDive) {
 				inner = applyConstraints(
 					inner,
-					constraints.filter((c) => c !== 'dive')
-				)
+					constraints.filter((c) => c !== 'dive'),
+				);
 			}
-			validator = `z.array(${inner})`
+			validator = `z.array(${inner})`;
 		} else {
-			validator = getBaseZodType(field.type, schema)
+			validator = getBaseZodType(field.type, schema);
 		}
 
 		// Apply constraints to outer
-		validator = applyConstraints(validator, partsToApply)
+		validator = applyConstraints(validator, partsToApply);
 
 		// ---- make optional ------------------------------------------------ //
 		if (isOptional) {
-			validator = `z.optional(${validator})`
+			validator = `z.optional(${validator})`;
 		}
 
-		return `  ${fieldName}: ${validator},`
-	})
+		return `  ${fieldName}: ${validator},`;
+	});
 
 	return `export const ${name}Schema = z.object({\n${zodFields.join(
-		'\n'
-	)}\n});\n\nexport type ${name}Input = z.infer<typeof ${name}Schema>;`
+		'\n',
+	)}\n});\n\nexport type ${name}Input = z.infer<typeof ${name}Schema>;`;
 }
 
 /* --------------------------------------------------------------------- */
 /* Helper: apply constraints to a base Zod validator string             */
 /* --------------------------------------------------------------------- */
 function applyConstraints(base: string, parts: string[]): string {
-	let v = base
+	let v = base;
 	for (const part of parts) {
-		const [tag, paramStr] = part.split('=')
-		const param = paramStr ?? null
+		const [tag, paramStr] = part.split('=');
+		const param = paramStr ?? null;
 		if (tag === 'min' && param !== null) {
-			v = `${v}.min(${param})`
+			v = `${v}.min(${param})`;
 		} else if (tag === 'max' && param !== null) {
-			v = `${v}.max(${param})`
+			v = `${v}.max(${param})`;
 		} else if (tag === 'len' && param !== null) {
-			v = `${v}.length(${param})`
+			v = `${v}.length(${param})`;
 		} else if (tag === 'lte' && param !== null) {
-			v = `${v}.max(${param})`
+			v = `${v}.max(${param})`;
 		} else if (tag === 'gte' && param !== null) {
-			v = `${v}.min(${param})`
+			v = `${v}.min(${param})`;
 		} else if (tag === 'email') {
-			v = `${v}.email()`
+			v = `${v}.email()`;
 		} else if (tag === 'url') {
-			v = `${v}.url()`
+			v = `${v}.url()`;
 		} else if (tag === 'startswith' && param !== null) {
-			const p = JSON.stringify(param)
-			v = `${v}.startsWith(${p})`
+			const p = JSON.stringify(param);
+			v = `${v}.startsWith(${p})`;
 		} else if (tag === 'endswith' && param !== null) {
-			const p = JSON.stringify(param)
-			v = `${v}.endsWith(${p})`
+			const p = JSON.stringify(param);
+			v = `${v}.endsWith(${p})`;
 		} else if (tag === 'startsnotwith' && param !== null) {
-			const p = JSON.stringify(param)
-			v = `${v}.refine(val => !val.startsWith(${p}))`
+			const p = JSON.stringify(param);
+			v = `${v}.refine(val => !val.startsWith(${p}))`;
 		} else if (tag === 'endsnotwith' && param !== null) {
-			const p = JSON.stringify(param)
-			v = `${v}.refine(val => !val.endsWith(${p}))`
+			const p = JSON.stringify(param);
+			v = `${v}.refine(val => !val.endsWith(${p}))`;
 		} else if (tag === 'contains' && param !== null) {
-			const p = JSON.stringify(param)
-			v = `${v}.includes(${p})`
+			const p = JSON.stringify(param);
+			v = `${v}.includes(${p})`;
 		} else if (tag === 'excludes' && param !== null) {
-			const p = JSON.stringify(param)
-			v = `${v}.refine(val => !val.includes(${p}))`
+			const p = JSON.stringify(param);
+			v = `${v}.refine(val => !val.includes(${p}))`;
 		} else if (tag === 'alpha') {
-			v = `${v}.regex(/^[a-zA-Z]+$/i)`
+			v = `${v}.regex(/^[a-zA-Z]+$/i)`;
 		} else if (tag === 'required') {
 			// Basic required handling: ensure non-empty for strings/arrays
 			if (v.includes('z.string') || v.includes('z.array')) {
-				v = `${v}.min(1)`
+				v = `${v}.min(1)`;
 			}
 		}
 		// Add more constraints here as needed from go-playground/validator tags
 	}
-	return v
+	return v;
 }
 
 /* --------------------------------------------------------------------- */
@@ -188,12 +187,12 @@ function applyConstraints(base: string, parts: string[]): string {
 /* --------------------------------------------------------------------- */
 function getValidateConstraint(field: any): string | null {
 	const dir: DirectiveNode | undefined = field.directives?.find(
-		(d: any) => d.name.value === 'validate'
-	)
-	if (!dir) return null
+		(d: any) => d.name.value === 'validate',
+	);
+	if (!dir) return null;
 
-	const arg = dir.arguments?.find((a: any) => a.name.value === 'constraint')
-	return arg?.value?.kind === 'StringValue' ? arg.value.value : null
+	const arg = dir.arguments?.find((a: any) => a.name.value === 'constraint');
+	return arg?.value?.kind === 'StringValue' ? arg.value.value : null;
 }
 
 /* --------------------------------------------------------------------- */
@@ -202,18 +201,18 @@ function getValidateConstraint(field: any): string | null {
 function getBaseZodType(typeNode: any, schema: GraphQLSchema): string {
 	// NonNull → recurse
 	if (typeNode.kind === 'NonNullType') {
-		return getBaseZodType(typeNode.type, schema)
+		return getBaseZodType(typeNode.type, schema);
 	}
 
 	// List
 	if (typeNode.kind === 'ListType') {
-		const inner = getBaseZodType(typeNode.type, schema)
-		return `z.array(${inner})`
+		const inner = getBaseZodType(typeNode.type, schema);
+		return `z.array(${inner})`;
 	}
 
 	// Named type
 	if (typeNode.kind === 'NamedType') {
-		const rawName = typeNode.name.value.replace(/\?$/, '') // strip ?
+		const rawName = typeNode.name.value.replace(/\?$/, ''); // strip ?
 		const scalarMap: Record<string, string> = {
 			String: 'z.string()',
 			Int: 'z.number().int()',
@@ -223,20 +222,20 @@ function getBaseZodType(typeNode: any, schema: GraphQLSchema): string {
 			UUID: 'z.string().uuid()',
 			Time: 'z.number()',
 			Upload: 'z.instanceof(File)',
-		}
+		};
 
-		if (scalarMap[rawName]) return scalarMap[rawName]
+		if (scalarMap[rawName]) return scalarMap[rawName];
 
 		// Enum
-		const gqlType = schema.getType(rawName)
+		const gqlType = schema.getType(rawName);
 		if (gqlType?.astNode?.kind === 'EnumTypeDefinition') {
-			const values = gqlType.astNode.values!.map((v: any) => `'${v.name.value}'`).join(', ')
-			return `z.enum([${values}])`
+			const values = gqlType.astNode.values!.map((v: any) => `'${v.name.value}'`).join(', ');
+			return `z.enum([${values}])`;
 		}
 
 		// Nested input → lazy
-		return `z.lazy(() => ${rawName}Schema)`
+		return `z.lazy(() => ${rawName}Schema)`;
 	}
 
-	return 'z.any()'
+	return 'z.any()';
 }

--- a/frontend/dashboard/src/api/openapi.ts
+++ b/frontend/dashboard/src/api/openapi.ts
@@ -1,4 +1,4 @@
-import { Api, HttpClient, type FullRequestParams, type HttpResponse } from '@twir/api/openapi';
+import { Api, type FullRequestParams, HttpClient, type HttpResponse } from '@twir/api/openapi';
 import { toast } from 'vue-sonner';
 
 // Create a wrapper that intercepts requests and handles errors

--- a/frontend/dashboard/src/components/command-menu/CommandMenu.vue
+++ b/frontend/dashboard/src/components/command-menu/CommandMenu.vue
@@ -11,11 +11,11 @@ import { useCommandMenuData } from '@/api/command-menu'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import { Button } from '@/components/ui/button'
 import {
-	Command as CommandRoot,
 	CommandEmpty,
 	CommandGroup,
 	CommandInput,
 	CommandList,
+	Command as CommandRoot,
 } from '@/components/ui/command'
 import {
 	Dialog,

--- a/frontend/dashboard/src/components/dashboard/custom-widget.vue
+++ b/frontend/dashboard/src/components/dashboard/custom-widget.vue
@@ -6,8 +6,8 @@ import { toast } from "vue-sonner";
 import Card from "./card.vue";
 import type { WidgetItem } from "@/components/dashboard/widgets.ts";
 import {
-	useDashboardWidgetsUpdateCustom,
 	useDashboardWidgetsDelete,
+	useDashboardWidgetsUpdateCustom,
 } from "@/api/dashboard-widgets-layout.ts";
 import { Button } from "@/components/ui/button";
 import { CardContent } from "@/components/ui/card";

--- a/frontend/dashboard/src/components/dashboard/widget-stacks.ts
+++ b/frontend/dashboard/src/components/dashboard/widget-stacks.ts
@@ -1,4 +1,4 @@
-import { computed, ref, type ComputedRef, type Ref, type WritableComputedRef } from 'vue';
+import { type ComputedRef, type Ref, type WritableComputedRef, computed, ref } from 'vue';
 import type { WidgetItem } from './widgets.ts';
 
 export function useWidgetStacks(

--- a/frontend/dashboard/src/components/dashboard/widgets.ts
+++ b/frontend/dashboard/src/components/dashboard/widgets.ts
@@ -1,4 +1,4 @@
-import { computed, ref, watch, nextTick } from 'vue';
+import { computed, nextTick, ref, watch } from 'vue';
 
 import type { LayoutItem } from 'grid-layout-plus';
 

--- a/frontend/dashboard/src/components/text-with-variables.vue
+++ b/frontend/dashboard/src/components/text-with-variables.vue
@@ -1,90 +1,88 @@
 <script lang="ts" setup>
-import { VariableIcon } from 'lucide-vue-next'
-import { computed, h } from 'vue'
+import { VariableIcon } from "lucide-vue-next";
+import { computed, h } from "vue";
 
-import { useVariablesApi } from '@/api/variables'
-import { Badge } from '@/components/ui/badge'
+import { useVariablesApi } from "@/api/variables";
+import { Badge } from "@/components/ui/badge";
 
-import type { HTMLAttributes, VNode } from 'vue'
+import type { HTMLAttributes, VNode } from "vue";
 
 const props = defineProps<{
-	text: string
-	class?: HTMLAttributes['class']
-}>()
+	text: string;
+	class?: HTMLAttributes["class"];
+}>();
 
-const { allVariables } = useVariablesApi()
+const { allVariables } = useVariablesApi();
 
 // Создаем Map для быстрого поиска переменных
 const variablesMap = computed(() => {
-	const map = new Map<string, { description: string | null; example: string }>()
+	const map = new Map<string, { description: string | null; example: string }>();
 
 	for (const variable of allVariables.value) {
 		map.set(variable.example, {
 			description: variable.description ?? null,
 			example: variable.example,
-		})
+		});
 	}
 
-	return map
-})
+	return map;
+});
 
 // Функция для парсинга текста и создания элементов
 function parseTextWithVariables(text: string): VNode[] {
-	const result: VNode[] = []
+	const result: VNode[] = [];
 	// Регулярное выражение для поиска переменных вида $(...)
-	const variableRegex = /\$\(([^)]+)\)/g
-	let lastIndex = 0
-	let match: RegExpExecArray | null
+	const variableRegex = /\$\(([^)]+)\)/g;
+	let lastIndex = 0;
 
-	while ((match = variableRegex.exec(text)) !== null) {
+	while (true) {
+		const match = variableRegex.exec(text);
+		if (match === null) break;
 		// Добавляем текст до переменной
 		if (match.index > lastIndex) {
-			result.push(h('span', {}, text.slice(lastIndex, match.index)))
+			result.push(h("span", {}, text.slice(lastIndex, match.index)));
 		}
 
-		const variableContent = match[1] // содержимое внутри $()
-		const fullMatch = match[0] // полное совпадение $()
-		const variableData = variablesMap.value.get(variableContent)
+		const variableContent = match[1]; // содержимое внутри $()
+		const fullMatch = match[0]; // полное совпадение $()
+		const variableData = variablesMap.value.get(variableContent);
 
 		// Создаем бейдж
 		result.push(
 			h(
 				Badge,
 				{
-					variant: 'default',
+					variant: "default",
 					class:
-						'mx-0.5 font-mono text-xs inline-flex rounded-md items-center gap-1 !whitespace-normal break-words max-w-full',
+						"mx-0.5 font-mono text-xs inline-flex rounded-md items-center gap-1 !whitespace-normal break-words max-w-full",
 				},
 				{
 					default: () => [
-						h(VariableIcon, { class: 'size-3 shrink-0' }),
-						h('span', { class: 'break-words' }, variableData?.description || fullMatch),
+						h(VariableIcon, { class: "size-3 shrink-0" }),
+						h("span", { class: "break-words" }, variableData?.description || fullMatch),
 					],
-				}
-			)
-		)
+				},
+			),
+		);
 
-		lastIndex = variableRegex.lastIndex
+		lastIndex = variableRegex.lastIndex;
 	}
 
 	// Добавляем оставшийся текст после последней переменной
 	if (lastIndex < text.length) {
-		result.push(h('span', {}, text.slice(lastIndex)))
+		result.push(h("span", {}, text.slice(lastIndex)));
 	}
 
-	return result
+	return result;
 }
 
 const renderedContent = computed(() => {
-	return parseTextWithVariables(props.text)
-})
+	return parseTextWithVariables(props.text);
+});
 </script>
 
 <template>
-	<div
-		:class="props.class"
-		class="break-words"
-	>
+	<div :class="props.class" class="break-words">
 		<component :is="() => renderedContent" />
 	</div>
 </template>

--- a/frontend/dashboard/src/features/commands/ui/list.vue
+++ b/frontend/dashboard/src/features/commands/ui/list.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
 import { getCoreRowModel, getExpandedRowModel, useVueTable } from "@tanstack/vue-table";
-import { colorBrightness, hexToRgb, type Rgb, rgbToHex } from "@zero-dependency/utils";
+import { type Rgb, colorBrightness, hexToRgb, rgbToHex } from "@zero-dependency/utils";
 import { ChevronDownIcon, ChevronRightIcon } from "lucide-vue-next";
 import { computed, h } from "vue";
 
 import ColumnActions from "./list-actions.vue";
-import { createGroups, type Group, isCommand } from "./list-groups.js";
+import { type Group, createGroups, isCommand } from "./list-groups.js";
 import Table from "@/components/table.vue";
 import TextWithVariables from "@/components/text-with-variables.vue";
 

--- a/frontend/dashboard/src/features/giveaways/ui/giveaways-create-dialog.vue
+++ b/frontend/dashboard/src/features/giveaways/ui/giveaways-create-dialog.vue
@@ -30,7 +30,8 @@ import {
 } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 import { useGiveaways } from "@/features/giveaways/composables/giveaways-use-giveaways.ts";
-import { ChannelRolePermissionEnum, GiveawayType } from "@/gql/graphql.ts";
+import type { GiveawayType } from "@/gql/graphql.ts";
+import { ChannelRolePermissionEnum } from "@/gql/graphql.ts";
 
 const { t } = useI18n();
 const open = ref(false);

--- a/frontend/dashboard/src/layout/stream-info-editor.vue
+++ b/frontend/dashboard/src/layout/stream-info-editor.vue
@@ -18,7 +18,7 @@ import {
 	DialogHeader,
 	DialogTitle,
 } from "@/components/ui/dialog";
-import { FormField, FormItem, FormLabel, FormControl, FormMessage } from "@/components/ui/form";
+import { FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { ChannelRolePermissionEnum } from "@/gql/graphql";
 

--- a/frontend/dashboard/src/pages/Dashboard.vue
+++ b/frontend/dashboard/src/pages/Dashboard.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { GridItem, GridLayout } from "grid-layout-plus";
-import { Layers, SquarePen, Plus } from "lucide-vue-next";
+import { Layers, Plus, SquarePen } from "lucide-vue-next";
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from "vue";
 
 import AuditLogs from "@/components/dashboard/audit-logs.vue";
@@ -10,7 +10,7 @@ import Events from "@/components/dashboard/events.vue";
 import Stream from "@/components/dashboard/stream.vue";
 import WidgetStackTabs from "@/components/dashboard/widget-stack-tabs.vue";
 import { useWidgetStacks } from "@/components/dashboard/widget-stacks.ts";
-import { useWidgets, type WidgetItem } from "@/components/dashboard/widgets.ts";
+import { type WidgetItem, useWidgets } from "@/components/dashboard/widgets.ts";
 import { Button } from "@/components/ui/button";
 import {
 	DropdownMenu,

--- a/frontend/dashboard/src/pages/settings/custom-widgets.vue
+++ b/frontend/dashboard/src/pages/settings/custom-widgets.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { Trash2, Plus } from "lucide-vue-next";
-import { ref, computed } from "vue";
+import { Plus, Trash2 } from "lucide-vue-next";
+import { computed, ref } from "vue";
 
 import {
 	useDashboardWidgetsCreateCustom,

--- a/frontend/overlays/src/composables/brb/use-brb-text-parser.ts
+++ b/frontend/overlays/src/composables/brb/use-brb-text-parser.ts
@@ -1,37 +1,37 @@
-import { type ComputedRef, computed } from 'vue'
+import { type ComputedRef, computed } from 'vue';
 
-import { useEmotes } from '@/composables/tmi/use-emotes.js'
+import { useEmotes } from '@/composables/tmi/use-emotes.js';
 
 export interface TextChunk {
-	type: 'text' | 'emote'
-	value: string
-	emoteWidth?: number
-	emoteHeight?: number
-	zeroWidthModifiers?: string[]
+	type: 'text' | 'emote';
+	value: string;
+	emoteWidth?: number;
+	emoteHeight?: number;
+	zeroWidthModifiers?: string[];
 }
 
 export function useBrbTextParser(text: ComputedRef<string | null>) {
-	const { emotes } = useEmotes()
+	const { emotes } = useEmotes();
 
 	const chunks = computed<TextChunk[]>(() => {
-		if (!text.value) return []
+		if (!text.value) return [];
 
-		const words = text.value.split(' ')
-		const result: TextChunk[] = []
+		const words = text.value.split(' ');
+		const result: TextChunk[] = [];
 
 		for (const word of words) {
-			const emote = emotes.value[word]
+			const emote = emotes.value[word];
 
 			if (emote) {
-				const isZeroWidthModifier = emote.isZeroWidth
+				const isZeroWidthModifier = emote.isZeroWidth;
 				// Use the highest quality emote (last URL in the array)
-				const emoteUrl = emote.urls[emote.urls.length - 1]
+				const emoteUrl = emote.urls[emote.urls.length - 1];
 
 				if (isZeroWidthModifier) {
 					// Add as zero-width modifier to the previous emote
-					const lastChunk = result[result.length - 1]
+					const lastChunk = result[result.length - 1];
 					if (lastChunk && lastChunk.type === 'emote') {
-						lastChunk.zeroWidthModifiers = [...(lastChunk.zeroWidthModifiers ?? []), emoteUrl]
+						lastChunk.zeroWidthModifiers = [...(lastChunk.zeroWidthModifiers ?? []), emoteUrl];
 					} else {
 						// If no previous emote, just add as regular emote
 						result.push({
@@ -39,7 +39,7 @@ export function useBrbTextParser(text: ComputedRef<string | null>) {
 							value: emoteUrl,
 							emoteWidth: emote.width,
 							emoteHeight: emote.height,
-						})
+						});
 					}
 				} else {
 					result.push({
@@ -47,26 +47,26 @@ export function useBrbTextParser(text: ComputedRef<string | null>) {
 						value: emoteUrl,
 						emoteWidth: emote.width,
 						emoteHeight: emote.height,
-					})
+					});
 				}
 			} else {
 				// If the last chunk is text, append to it with a space
-				const lastChunk = result[result.length - 1]
+				const lastChunk = result[result.length - 1];
 				if (lastChunk && lastChunk.type === 'text') {
-					lastChunk.value += ' ' + word
+					lastChunk.value += ` ${word}`;
 				} else {
 					result.push({
 						type: 'text',
 						value: word,
-					})
+					});
 				}
 			}
 		}
 
-		return result
-	})
+		return result;
+	});
 
 	return {
 		chunks,
-	}
+	};
 }

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
   "devDependencies": {
     "@types/bun": "catalog:",
     "@types/node": "25.0.3",
-    "oxfmt": "0.40.0",
-    "oxlint": "1.55.0",
-    "oxlint-tsgolint": "0.16.0",
+    "oxfmt": "0.44.0",
+    "oxlint": "1.59.0",
+    "oxlint-tsgolint": "0.20.0",
     "prettier": "3.6.2",
     "rimraf": "5.0.5",
     "typescript": "catalog:"

--- a/web/layers/pastebin/components/pastebin/paste-card.vue
+++ b/web/layers/pastebin/components/pastebin/paste-card.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
-import type { PasteBinOutputDto } from '@twir/api/openapi';
-import { toast } from 'vue-sonner';
-import Button from '@/components/ui/button/Button.vue';
-import DeletePasteDialog from './delete-paste-dialog.vue';
+import type { PasteBinOutputDto } from "@twir/api/openapi";
+import { toast } from "vue-sonner";
+import Button from "@/components/ui/button/Button.vue";
+import DeletePasteDialog from "./delete-paste-dialog.vue";
 
 const props = defineProps<{
 	paste: PasteBinOutputDto;
@@ -34,7 +34,7 @@ function formatDate(date: string) {
 const previewContent = computed(() => {
 	const maxLength = 200;
 	if (props.paste.content.length > maxLength) {
-		return props.paste.content.slice(0, maxLength) + "...";
+		return `${props.paste.content.slice(0, maxLength)}...`;
 	}
 	return props.paste.content;
 });
@@ -101,7 +101,8 @@ const isExpired = computed(() => {
 								:class="{ 'text-red-400': isExpired }"
 							/>
 							<span :class="{ 'text-red-400': isExpired }">
-								{{ isExpired ? "Expired" : "Expires" }}: {{ paste.expire_at ? formatDate(paste.expire_at) : '' }}
+								{{ isExpired ? "Expired" : "Expires" }}:
+								{{ paste.expire_at ? formatDate(paste.expire_at) : "" }}
 							</span>
 						</span>
 					</div>

--- a/web/layers/public/components/commands/commands-name-cell.vue
+++ b/web/layers/public/components/commands/commands-name-cell.vue
@@ -1,17 +1,17 @@
 <script setup lang="ts">
 const props = defineProps<{
-	name: string
-	aliases: string[]
-}>()
+	name: string;
+	aliases: string[];
+}>();
 
-const mappedAliases = props.aliases.join(', ')
+const mappedAliases = props.aliases.join(", ");
 </script>
 
 <template>
 	<UiTooltip v-if="aliases.length">
 		<UiTooltipTrigger>
 			<span>{{ name }}</span>
-		</UITooltipTrigger>
+		</UiTooltipTrigger>
 		<UiTooltipContent>
 			{{ mappedAliases }}
 		</UiTooltipContent>


### PR DESCRIPTION
## Summary

Обновление oxc инструментов до последних версий и настройка сортировки импортов.

### Changes

**Package Updates:**

- oxlint: 1.55.0 → 1.59.0
- oxfmt: 0.40.0 → 0.44.0
- oxlint-tsgolint: 0.16.0 → 0.20.0

**Import Sorting Configuration (.oxfmtrc.jsonc):**

- Настроен порядок групп: builtin → external → internal → parent/sibling/index
- Type imports идут первыми в каждой группе
- Добавлены разделители между группами

**Lint Fixes:**

- Удалены неиспользуемые импорты
- Исправлен алфавитный порядок членов в импортах
- Исправлено присваивание в условии (no-cond-assign)
- Конкатенации заменены на template literals (prefer-template)
- Добавлен override для no-alert в файлах с confirm()
- Исправлена опечатка в Vue компоненте (регистр тега)

### Verification

```bash
bun lint  # ✓ 0 warnings, 0 errors
```
