### PR TITLE
fix(shortened-urls): add ignore_global_bans to Update RETURNING clause

### DIFF
--- a/libs/repositories/shortened_urls/datasource/postgres/pgx.go
+++ b/libs/repositories/shortened_urls/datasource/postgres/pgx.go
@@ -202,7 +202,7 @@ func (c *Pgx) Update(
 	updateBuilder := sq.Update("shortened_urls").
 		Where(squirrel.Eq{"short_id": id}).
 		Set("updated_at", squirrel.Expr("NOW()")).
-		Suffix("RETURNING short_id, created_at, updated_at, url, created_by_user_id, views, user_ip, user_agent, domain_id")
+		Suffix("RETURNING short_id, created_at, updated_at, url, created_by_user_id, views, user_ip, user_agent, domain_id, ignore_global_bans")
 
 	if domainID == nil {
 		updateBuilder = updateBuilder.Where("domain_id IS NULL")


### PR DESCRIPTION
## Summary

- The `Update` function in `libs/repositories/shortened_urls/datasource/postgres/pgx.go` wraps the squirrel `UPDATE ... RETURNING ...` inside a CTE alias `updated`, then selects from it via `selectColumnsCteStr` which includes `updated.ignore_global_bans`.
- The `RETURNING` clause was missing `ignore_global_bans`, causing Postgres to error: `column updated.ignore_global_bans does not exist`.
- Fixed by adding `ignore_global_bans` to the `RETURNING` suffix so the CTE exposes the column.

## Root Cause

```go
// Before (broken)
Suffix("RETURNING short_id, created_at, updated_at, url, created_by_user_id, views, user_ip, user_agent, domain_id")

// After (fixed)
Suffix("RETURNING short_id, created_at, updated_at, url, created_by_user_id, views, user_ip, user_agent, domain_id, ignore_global_bans")
```