### PR TITLE
feat(stack): add anubis anti-bot in front of web

### DIFF
--- a/PRODUCTION.md
+++ b/PRODUCTION.md
@@ -48,6 +48,12 @@ echo "twir" | docker secret create twir_postgres_password -
 echo "super-secret-webhook-token" | docker secret create twir_deploy_webhook_token -
 ```
 
+### Anubis secret
+
+```bash
+printf %s "$(openssl rand -hex 32)" | docker secret create twir_anubis_ed25519_key -
+```
+
 ## First deploy
 
 For the first deploy, choose the image tag that already exists in the registry and export it before deploying.

--- a/configs/anubis/botPolicies.yaml
+++ b/configs/anubis/botPolicies.yaml
@@ -1,0 +1,115 @@
+# Anubis bot policy for the public site (twir.app / cf.twir.app).
+# Based on the upstream default policy (data/botPolicies.yaml in
+# https://github.com/TecharoHQ/anubis) with two changes:
+#   - Thoth-only (paid) geoip/asn WEIGH rules removed
+#   - Open Graph passthrough enabled, so social/messenger link previews
+#     keep working without solving proof-of-work
+bots:
+  # Pathological bots to deny
+  - import: (data)/bots/_deny-pathological.yaml
+  - import: (data)/bots/aggressive-brazilian-scrapers.yaml
+
+  # Aggressively block AI/LLM related bots/agents by default.
+  # Consider replacing with a more selective policy if this is too strict:
+  # - import: (data)/meta/ai-block-moderate.yaml
+  # - import: (data)/meta/ai-block-permissive.yaml
+  - import: (data)/meta/ai-block-aggressive.yaml
+
+  # Search engine crawlers to allow, defaults to:
+  #   - Google (so they don't try to bypass Anubis)
+  #   - Apple
+  #   - Bing
+  #   - DuckDuckGo
+  #   - Qwant
+  #   - The Internet Archive
+  #   - Kagi
+  #   - Marginalia
+  #   - Mojeek
+  - import: (data)/crawlers/_allow-good.yaml
+
+  # Challenge Firefox AI previews
+  - import: (data)/clients/x-firefox-ai.yaml
+
+  # x.ai has a scraper that is killing gitlab instances
+  - import: (data)/crawlers/xai.yaml
+
+  # Allow common "keeping the internet working" routes (well-known, favicon, robots.txt)
+  - import: (data)/common/keep-internet-working.yaml
+
+  # Generic catchall rule
+  - name: generic-browser
+    user_agent_regex: >-
+      Mozilla|Opera
+    action: WEIGH
+    weight:
+      adjust: 10
+
+dnsbl: false
+
+# Honeypot configuration
+honeypot:
+  enabled: true
+  implementation: naive
+
+# Open Graph passthrough, see:
+# https://anubis.techaro.lol/docs/admin/configuration/open-graph/
+openGraph:
+  enabled: true
+  considerHost: true
+  ttl: 24h
+
+# By default, send HTTP 200 back to clients that either get issued a challenge
+# or a denial. This seems weird, but this is load-bearing due to the fact that
+# the most aggressive scraper bots seem to really, really, want an HTTP 200 and
+# will stop sending requests once they get it.
+status_codes:
+  CHALLENGE: 200
+  DENY: 200
+
+# In-memory store: fine for short-lived challenges. If we ever switch to a
+# persistent backend (bbolt), ED25519_PRIVATE_KEY_HEX_FILE is already wired.
+store:
+  backend: memory
+  parameters: {}
+
+# Weight thresholds deciding when to challenge and how hard.
+# Any explicit CHALLENGE action in bot rules takes precedence over these.
+thresholds:
+  - name: minimal-suspicion
+    expression: weight <= 0
+    action: ALLOW
+  - name: mild-suspicion
+    expression:
+      all:
+        - weight > 0
+        - weight < 10
+    action: CHALLENGE
+    challenge:
+      # https://anubis.techaro.lol/docs/admin/configuration/challenges/metarefresh
+      algorithm: metarefresh
+      difficulty: 1
+  - name: moderate-suspicion
+    expression:
+      all:
+        - weight >= 10
+        - weight < 20
+    action: CHALLENGE
+    challenge:
+      # https://anubis.techaro.lol/docs/admin/configuration/challenges/proof-of-work
+      algorithm: fast
+      difficulty: 2
+  - name: mild-proof-of-work
+    expression:
+      all:
+        - weight >= 20
+        - weight < 30
+    action: CHALLENGE
+    challenge:
+      algorithm: fast
+      difficulty: 4
+  - name: extreme-suspicion
+    expression: weight >= 30
+    action: CHALLENGE
+    challenge:
+      algorithm: fast
+      difficulty: 6

--- a/configs/anubis/botPolicies.yaml
+++ b/configs/anubis/botPolicies.yaml
@@ -66,11 +66,13 @@ status_codes:
   CHALLENGE: 200
   DENY: 200
 
-# In-memory store: fine for short-lived challenges. If we ever switch to a
-# persistent backend (bbolt), ED25519_PRIVATE_KEY_HEX_FILE is already wired.
+# Shared state (issued challenges) for all Anubis replicas lives in the
+# stack's Redis, so a challenge created by one replica validates on another.
+# Logical db 1 is reserved for Anubis; applications use db 0.
 store:
-  backend: memory
-  parameters: {}
+  backend: valkey
+  parameters:
+    url: "redis://redis:6379/1"
 
 # Weight thresholds deciding when to challenge and how hard.
 # Any explicit CHALLENGE action in bot rules takes precedence over these.

--- a/docker-compose.stack.yml
+++ b/docker-compose.stack.yml
@@ -634,10 +634,32 @@ services:
         max_attempts: 30
       endpoint_mode: dnsrr
 
-  web:
-    image: registry.twir.app/twirapp/web:${TWIR_IMAGE_TAG:-latest}
+  # Anubis (https://anubis.techaro.lol) sits between Traefik and the public site:
+  #   Traefik -> anubis (proof-of-work anti-bot challenge) -> web
+  # Only the public catch-all routers go through it. /api, /s/, /overlays and /socket
+  # keep their priority-20 routes straight to the backing services: API clients,
+  # OBS browser sources and websockets cannot solve proof-of-work.
+  #
+  # Required one-time setup on the swarm manager:
+  #   printf %s "$(openssl rand -hex 32)" | docker secret create twir_anubis_ed25519_key -
+  # All replicas must share the same key, otherwise a pass-cookie issued by one
+  # replica is rejected by another and clients loop on the challenge page.
+  anubis:
+    image: ghcr.io/techarohq/anubis:v1.26.0
+    environment:
+      BIND: ":8923"
+      TARGET: http://web:3000
+      POLICY_FNAME: /etc/anubis/botPolicies.yaml
+      ED25519_PRIVATE_KEY_HEX_FILE: /run/secrets/twir_anubis_ed25519_key
+      COOKIE_DOMAIN: twir.app
+      COOKIE_SAME_SITE: Lax
+      # The site ships no own robots.txt; let Anubis serve one disallowing AI scrapers.
+      SERVE_ROBOTS_TXT: "true"
     secrets:
-      - twir_doppler_token
+      - twir_anubis_ed25519_key
+    configs:
+      - source: anubis_bot_policies
+        target: /etc/anubis/botPolicies.yaml
     networks:
       - twir
       - traefik-public
@@ -657,7 +679,33 @@ services:
         - "traefik.http.routers.cf-web.service=twir-web"
         - "traefik.http.routers.cf-web.middlewares=gzip,rate-limit"
         - "traefik.http.routers.cf-web.priority=10"
-        - "traefik.http.services.twir-web.loadbalancer.server.port=3000"
+        - "traefik.http.services.twir-web.loadbalancer.server.port=8923"
+      update_config:
+        order: start-first
+        parallelism: 1
+      restart_policy:
+        condition: any
+        delay: 30s
+        max_attempts: 30
+      resources:
+        limits:
+          cpus: "0.5"
+          memory: 256M
+      mode: replicated
+      replicas: 2
+      endpoint_mode: dnsrr
+      placement:
+        constraints:
+          - node.labels.databases != true
+
+  # Intentionally has no Traefik labels: public traffic reaches the site through `anubis`.
+  web:
+    image: registry.twir.app/twirapp/web:${TWIR_IMAGE_TAG:-latest}
+    secrets:
+      - twir_doppler_token
+    networks:
+      - twir
+    deploy:
       update_config:
         order: start-first
         parallelism: 2
@@ -948,6 +996,9 @@ configs:
   clickhouse_config:
     file: ./configs/clickhouse-config.xml
 
+  anubis_bot_policies:
+    file: ./configs/anubis/botPolicies.yaml
+
   pgdog_users_config:
     file: ./configs/pgdog/users.toml
   pgdog_config:
@@ -982,4 +1033,6 @@ secrets:
   twir_postgres_password:
     external: true
   twir_deploy_webhook_token:
+    external: true
+  twir_anubis_ed25519_key:
     external: true

--- a/docker-compose.stack.yml
+++ b/docker-compose.stack.yml
@@ -691,8 +691,11 @@ services:
         limits:
           cpus: "0.5"
           memory: 256M
+        reservations:
+          cpus: "0.1"
+          memory: 128M
       mode: replicated
-      replicas: 2
+      replicas: 3
       endpoint_mode: dnsrr
       placement:
         constraints:


### PR DESCRIPTION
## What

Adds [Anubis](https://anubis.techaro.lol) (proof-of-work anti-bot firewall, `ghcr.io/techarohq/anubis:v1.26.0`) to the production swarm stack to shield the public site from AI scrapers.

Traffic flow becomes:

```
Traefik -> anubis (PoW challenge) -> web (Nuxt)
```

## How

- New `anubis` service (2 replicas, dnsrr) takes over the `twir-web` / `cf-web` catch-all routers (priority 10) from `web`; router names, rules and middlewares (`gzip`, `rate-limit`) are unchanged.
- `web` loses its Traefik labels and the `traefik-public` network — it is only reachable internally via `anubis`.
- Path-specific priority-20 routes (`/api`, `/s/`, `/overlays`, `/socket`) are **not** touched: API clients, OBS browser sources and websockets cannot solve proof-of-work.
- Bot policy at `configs/anubis/botPolicies.yaml` (swarm config): upstream default minus Thoth-only (paid) geoip/asn rules, with Open Graph passthrough enabled so social/messenger link previews keep working.
- Replica state (issued challenges) is shared through the existing `redis` service via Anubis' `valkey` store backend (logical db 1, apps use db 0), so a challenge created by one replica validates on another. Pass-cookies are JWTs signed by the shared ed25519 key from the swarm secret. The default `memory` backend is documented as not-for-production and single-instance only.
- `SERVE_ROBOTS_TXT=true` — the site ships no own `robots.txt`, Anubis serves one disallowing known AI scrapers.

## Required before deploy (one-time, swarm manager)

All replicas must share one signing key, otherwise a pass-cookie issued by one replica is rejected by another and clients loop on the challenge page:

```bash
printf %s "$(openssl rand -hex 32)" | docker secret create twir_anubis_ed25519_key -
```

(also added to PRODUCTION.md)

## Notes

- Image pinned to `v1.26.0` (latest tagged release).
- Pass-cookie: domain `twir.app` (covers `cf.twir.app`), `SameSite=Lax`, 168h lifetime (default).
- Verified: `docker compose -f docker-compose.stack.yml config` renders cleanly, policy YAML parses.