### PR TITLE
fix(stack): let robots.txt pass through anubis for seo

### DIFF
--- a/docker-compose.stack.yml
+++ b/docker-compose.stack.yml
@@ -653,8 +653,6 @@ services:
       ED25519_PRIVATE_KEY_HEX_FILE: /run/secrets/twir_anubis_ed25519_key
       COOKIE_DOMAIN: twir.app
       COOKIE_SAME_SITE: Lax
-      # The site ships no own robots.txt; let Anubis serve one disallowing AI scrapers.
-      SERVE_ROBOTS_TXT: "true"
     secrets:
       - twir_anubis_ed25519_key
     configs:


### PR DESCRIPTION
Follow-up to #1007.

## What

Drops `SERVE_ROBOTS_TXT=true` from the anubis service.

## Why

Anubis' built-in `robots.txt` (served when `SERVE_ROBOTS_TXT` is on, intercepted before the backend) ends with:

```
User-agent: *
Disallow: /
```

That blanket-disallows crawling for **every** agent, Google included — it would deindex twir.app. The file is meant for sites that want to close off entirely, not for a public landing with SEO.

Without the flag, `/robots.txt` falls through to Nuxt (404 = no restrictions for crawlers). Search engines are still allowed at the policy level: `_allow-good.yaml` issues `ALLOW` for Googlebot (verified against Google's published IP ranges, so it can't be spoofed by UA), Bing, DuckDuckGo, Yandex, Apple, Qwant, Kagi, Marginalia, Mojeek, Internet Archive and Common Crawl.

If we later want AI-scraper rules in robots.txt, the right place is a `robots.txt` in the web app itself, not the Anubis built-in one.