### PR TITLE
fix(migrations): add new now-playing preset values to postgres enum

### DIFF
--- a/libs/migrations/postgres/20260726183525_now_playing_preset_add_new_values.sql
+++ b/libs/migrations/postgres/20260726183525_now_playing_preset_add_new_values.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+-- +goose NO TRANSACTION
+ALTER TYPE channel_overlay_now_playing_preset ADD VALUE IF NOT EXISTS 'PULSE_STRIP';
+ALTER TYPE channel_overlay_now_playing_preset ADD VALUE IF NOT EXISTS 'AURA_STACK';
+ALTER TYPE channel_overlay_now_playing_preset ADD VALUE IF NOT EXISTS 'VINYL_HAZE';
+ALTER TYPE channel_overlay_now_playing_preset ADD VALUE IF NOT EXISTS 'SIGNAL_DECK';
+
+-- +goose Down
+-- +goose NO TRANSACTION
+-- PostgreSQL does not support removing values from an enum type; left as a no-op.
+SELECT 1;


### PR DESCRIPTION
## Проблема

В дашборде для now-playing оверлея доступны 7 пресетов, но при сохранении любого из новых (Pulse Strip, Aura Stack, Vinyl Haze, Signal Deck) мутация падает:

```
ERROR: invalid input value for enum channel_overlay_now_playing_preset: "AURA_STACK" (SQLSTATE 22P02)
```

Из-за этого пресет в БД не сохранялся, и оверлей в OBS продолжал показывать старый стиль (например, Simple Line).

## Причина

Postgres-enum `channel_overlay_now_playing_preset` содержал только `TRANSPARENT`, `AIDEN_REDESIGN`, `SIMPLE_LINE` — миграция для новых значений не была добавлена вместе с пресетами.

## Исправление

Миграция `20260726183525_now_playing_preset_add_new_values.sql`: `ALTER TYPE ... ADD VALUE IF NOT EXISTS` для `PULSE_STRIP`, `AURA_STACK`, `VINYL_HAZE`, `SIGNAL_DECK` (с `-- +goose NO TRANSACTION`, как в `20260724020936_platform_enum_add_vk_video_live.sql`).

Проверено на локальной БД: enum расширяется до 7 значений, миграция идемпотентна.