### PR TITLE
fix: now playing cache read ptr fields and song requests uuid parse

### DIFF
--- a/apps/api-gql/internal/delivery/gql/now-playing-fetcher/now-playing-fetcher.go
+++ b/apps/api-gql/internal/delivery/gql/now-playing-fetcher/now-playing-fetcher.go
@@ -172,9 +172,12 @@ func (c *NowPlayingFetcher) Fetch(ctx context.Context) (*Track, error) {
 func (c *NowPlayingFetcher) fetchWrapper(ctx context.Context) (*Track, error) {
 	redisKey := fmt.Sprintf("overlays:nowplaying:%s", c.channelId)
 
-	cachedTrack := &Track{}
-	err := c.kv.Get(ctx, redisKey).Scan(cachedTrack)
+	cachedData, err := c.kv.Get(ctx, redisKey).Bytes()
 	if err == nil {
+		cachedTrack := &Track{}
+		if err := cachedTrack.UnmarshalBinary(cachedData); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal cached now playing track: %w", err)
+		}
 		cachedTrack.advanceProgress(time.Now())
 		cachedTrack.fromCache = true
 		return cachedTrack, nil

--- a/apps/parser/internal/commands/songrequest/youtube/sr.go
+++ b/apps/parser/internal/commands/songrequest/youtube/sr.go
@@ -81,7 +81,7 @@ var SrCommand = &types.DefaultCommand{
 		}
 
 		if moduleSettings.AcceptOnlyWhenOnline {
-			channelUUID, err := googleuuid.Parse(parseCtx.Channel.ID)
+			channelUUID, err := googleuuid.Parse(parseCtx.Channel.DBChannelID)
 			if err != nil {
 				return nil, &types.CommandHandlerError{
 					Message: i18n.GetCtx(ctx, locales.Translations.Commands.Songrequest.Errors.GetSettings),


### PR DESCRIPTION
## Fixes two production errors

### 1. api-gql — `failed to set field ProgressMs: unsupported field type: ptr`

`nowPlayingCurrentTrackSubscription` logged this every poll and the now playing overlay broke whenever a cached track had progress/duration.

**Root cause:** `fetchWrapper` read the cached `Track` via `kv.Get(...).Scan()`, which uses reflection in `twirapp/kv` scanner — it has no `reflect.Ptr` case, so `*int` fields (`ProgressMs`, `DurationMs`) always failed to decode.

**Fix:** read raw bytes and decode via `Track.UnmarshalBinary` (encoding/json handles pointers). Already covered by `TestTrackBinaryRoundTripPreservesTiming`. This was the only `kv.Get(...).Scan(...)` call site in the repo; upstream `twirapp/kv` should eventually get pointer support in its scanner.

### 2. parser — `invalid UUID length: 10` / "Cannot get song requests settings"

`!sr` failed for channels with `AcceptOnlyWhenOnline` enabled.

**Root cause:** `sr.go` parsed `parseCtx.Channel.ID` (platform-specific Twitch numeric ID, e.g. `1100730352` — 10 chars) as a UUID for the `IsChannelOnline` check.

**Fix:** parse `parseCtx.Channel.DBChannelID` (internal `channels.id` UUID), which is what `ChannelService.IsChannelOnline` expects.

## Verification

- `go build ./apps/api-gql/... ./apps/parser/...` — OK
- `go test` for `now-playing-fetcher`, `resolvers`, `commands/songrequest` — 24 passed