### PR TITLE
fix(executron): pass all fetch options through sandbox capability

### DIFF
--- a/apps/executron/src/libs/executor-fetch.test.ts
+++ b/apps/executron/src/libs/executor-fetch.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, mock, test } from 'bun:test'
+
+import type { FetchResponse } from './host-fetch'
+
+const hostFetchMock = mock(
+	async (_url: string, _options?: RequestInit): Promise<FetchResponse> => ({
+		status: 200,
+		statusText: 'OK',
+		headers: { 'content-type': 'application/json' },
+		body: '{"ok":true}',
+	})
+)
+
+mock.module('./host-fetch', () => ({ hostFetch: hostFetchMock }))
+
+const { executeCode } = await import('./executor')
+
+describe('executeCode fetch options passthrough', () => {
+	test('passes method, headers and body to hostFetch', async () => {
+		hostFetchMock.mockClear()
+
+		const execution = await executeCode(
+			`
+				const res = await fetch('https://example.com/api', {
+					method: 'POST',
+					headers: {
+						'Content-Type': 'application/json',
+						'X-Api-Key': 'secret-key',
+					},
+					body: JSON.stringify({ hello: 'world' }),
+				});
+				const data = await res.json();
+				return JSON.stringify({ status: res.status, ok: res.ok, data });
+			`,
+			'test-channel',
+			new Map()
+		)
+
+		expect(execution.error).toBe('')
+		expect(JSON.parse(execution.result)).toEqual({
+			status: 200,
+			ok: true,
+			data: { ok: true },
+		})
+
+		expect(hostFetchMock).toHaveBeenCalledTimes(1)
+		const [url, opts] = hostFetchMock.mock.calls[0] as unknown as [string, RequestInit]
+		expect(url).toBe('https://example.com/api')
+		expect(opts.method).toBe('POST')
+		expect(opts.headers).toEqual({
+			'Content-Type': 'application/json',
+			'X-Api-Key': 'secret-key',
+		})
+		expect(opts.body).toBe('{"hello":"world"}')
+		expect(opts.signal).toBeInstanceOf(AbortSignal)
+	})
+
+	test('passes headers given as array of tuples', async () => {
+		hostFetchMock.mockClear()
+
+		const execution = await executeCode(
+			`
+				await fetch('https://example.com/api', {
+					headers: [['X-First', '1'], ['X-Second', '2']],
+				});
+				return 'done';
+			`,
+			'test-channel',
+			new Map()
+		)
+
+		expect(execution.error).toBe('')
+		const [, opts] = hostFetchMock.mock.calls[0] as unknown as [string, RequestInit]
+		expect(opts.headers).toEqual({ 'X-First': '1', 'X-Second': '2' })
+	})
+
+	test('passes misc request options through', async () => {
+		hostFetchMock.mockClear()
+
+		const execution = await executeCode(
+			`
+				await fetch('https://example.com/api', {
+					credentials: 'include',
+					mode: 'cors',
+					referrer: 'https://example.com/page',
+				});
+				return 'done';
+			`,
+			'test-channel',
+			new Map()
+		)
+
+		expect(execution.error).toBe('')
+		const [, opts] = hostFetchMock.mock.calls[0] as unknown as [string, RequestInit]
+		expect(opts.credentials).toBe('include')
+		expect(opts.mode).toBe('cors')
+		expect(opts.referrer).toBe('https://example.com/page')
+	})
+
+	test('works without options at all', async () => {
+		hostFetchMock.mockClear()
+
+		const execution = await executeCode(
+			`
+				const res = await fetch('https://example.com/api');
+				return res.status;
+			`,
+			'test-channel',
+			new Map()
+		)
+
+		expect(execution.error).toBe('')
+		expect(execution.result).toBe('200')
+
+		const [, opts] = hostFetchMock.mock.calls[0] as unknown as [string, RequestInit]
+		expect(opts.method).toBeUndefined()
+		expect(opts.headers).toBeUndefined()
+		expect(opts.body).toBeUndefined()
+	})
+})

--- a/apps/executron/src/libs/executor.ts
+++ b/apps/executron/src/libs/executor.ts
@@ -95,17 +95,25 @@ export async function executeCode(
 		console.log(`[executron] Creating fetchCapability...`)
 		const fetchCapability = await realm.createCapability(
 			() => ({
-				startFetch(id: unknown, url: unknown, method: unknown, body: unknown) {
-					const numId = Number(id)
-					const controller = new AbortController()
-					pendingFetchControllers.set(numId, controller)
+			startFetch(id: unknown, url: unknown, optionsJson: unknown) {
+				const numId = Number(id)
+				const controller = new AbortController()
+				pendingFetchControllers.set(numId, controller)
 
-					const opts: RequestInit = {}
-					if (method) opts.method = String(method)
-					if (body) opts.body = String(body)
-					opts.signal = controller.signal
+				const opts: RequestInit = {}
+				if (optionsJson) {
+					try {
+						const parsed = JSON.parse(String(optionsJson)) as RequestInit
+						if (parsed && typeof parsed === 'object') {
+							Object.assign(opts, parsed)
+						}
+					} catch (err: any) {
+						console.error(`[executron] Fetch #${numId}: failed to parse options:`, err.message)
+					}
+				}
+				opts.signal = controller.signal
 
-					console.log(`[executron] Fetch #${numId}: ${method || 'GET'} ${url}`)
+				console.log(`[executron] Fetch #${numId}: ${opts.method || 'GET'} ${url}`)
 					const fetchStart = Date.now()
 
 					void hostFetch(String(url), opts).then(
@@ -333,28 +341,64 @@ export async function executeCode(
 				}
 			};
 
-			function fetch(url, options) {
-				const signal = options?.signal;
-				if (signal?.aborted) {
-					return Promise.reject(new DOMException('The operation was aborted.', 'AbortError'));
+		function __serializeFetchHeaders(headers) {
+			if (!headers) return undefined;
+
+			const out = {};
+			if (Array.isArray(headers)) {
+				for (const pair of headers) {
+					if (pair && pair.length >= 2) out[String(pair[0])] = String(pair[1]);
+				}
+			} else if (typeof headers.forEach === 'function') {
+				headers.forEach((value, key) => { out[String(key)] = String(value); });
+			} else if (typeof headers === 'object') {
+				for (const key of Object.keys(headers)) out[String(key)] = String(headers[key]);
+			}
+			return out;
+		}
+
+		function __serializeFetchOptions(options) {
+			if (!options) return null;
+
+			const out = {};
+			if (options.method) out.method = String(options.method);
+			if (options.body != null) {
+				out.body = typeof options.body === 'string' ? options.body : String(options.body);
+			}
+
+			const headers = __serializeFetchHeaders(options.headers);
+			if (headers) out.headers = headers;
+
+			const passthrough = ['mode', 'credentials', 'cache', 'redirect', 'referrer', 'referrerPolicy', 'integrity', 'keepalive', 'priority', 'duplex'];
+			for (const key of passthrough) {
+				if (options[key] !== undefined) out[key] = options[key];
+			}
+
+			return JSON.stringify(out);
+		}
+
+		function fetch(url, options) {
+			const signal = options?.signal;
+			if (signal?.aborted) {
+				return Promise.reject(new DOMException('The operation was aborted.', 'AbortError'));
+			}
+
+			return new Promise((resolve, reject) => {
+				const id = __nextFetchId++;
+				__fetchResolvers.set(id, { resolve, reject });
+
+				if (signal) {
+					const onAbort = () => {
+						__fetchResolvers.delete(id);
+						abortFetch(id);
+						reject(new DOMException('The operation was aborted.', 'AbortError'));
+					};
+					signal.addEventListener('abort', onAbort);
 				}
 
-				return new Promise((resolve, reject) => {
-					const id = __nextFetchId++;
-					__fetchResolvers.set(id, { resolve, reject });
-
-					if (signal) {
-						const onAbort = () => {
-							__fetchResolvers.delete(id);
-							abortFetch(id);
-							reject(new DOMException('The operation was aborted.', 'AbortError'));
-						};
-						signal.addEventListener('abort', onAbort);
-					}
-
-					startFetch(id, url, options?.method || null, options?.body || null);
-				});
-			}
+				startFetch(id, url, __serializeFetchOptions(options));
+			});
+		}
 
 			globalThis.fetch = fetch;
 


### PR DESCRIPTION
## Problem

The sandboxed `fetch` shim in `apps/executron` forwarded only `method` and `body` to the host `startFetch` capability:

```ts
startFetch(id, url, options?.method || null, options?.body || null);
```

Everything else in `RequestInit` — most notably `headers` — was silently dropped at the capability boundary, so user scripts could not set request headers (auth tokens, content types, etc.).

## Fix

- **Sandbox side** (`executor.ts` wrapped code): serialize the full options object to JSON before crossing the capability boundary:
  - `headers` normalized from all supported forms — plain object, array of tuples, and `Headers`-like (anything with `forEach`)
  - `method`, `body` (stringified), plus `mode`, `credentials`, `cache`, `redirect`, `referrer`, `referrerPolicy`, `integrity`, `keepalive`, `priority`, `duplex`
- **Host side** (`startFetch` capability): parse the JSON and rebuild `RequestInit`, then pass it to `hostFetch` (which already merges headers via `new Headers(options?.headers)`).

## Deliberately unchanged

- `signal` is still managed host-side via the per-request `AbortController` (sandbox abort flow untouched).
- `hostFetch` keeps forcing `redirect: 'error'` — following redirects would bypass `validateUrl` SSRF protection, since only the initial URL is validated.

## Tests

New `executor-fetch.test.ts` (mocks `host-fetch`, captures options at the boundary):

- headers + method + body passthrough
- headers as array of tuples
- misc options (`credentials`, `mode`, `referrer`)
- fetch without options

```
5 pass, 0 fail (incl. existing lodash test)
```

`tsc --noEmit` clean; `oxlint` reports no new issues (one pre-existing import-order error in `host-fetch.ts` on main, untouched).