### PR TITLE
feat: platform binding for command responses

### DIFF
--- a/apps/api-gql/internal/delivery/gql/dataloader/commands_responses.go
+++ b/apps/api-gql/internal/delivery/gql/dataloader/commands_responses.go
@@ -21,7 +21,12 @@ func (c *dataLoader) getCommandsResponsesByIDs(ctx context.Context, commandsIDs 
 	for i, commandResponses := range responses {
 		mappedCommandResponses := make([]gqlmodel.CommandResponse, 0, len(commandResponses))
 		for _, r := range commandResponses {
-			mappedCommandResponses = append(mappedCommandResponses, mappers.CommandResponseTo(r))
+			mappedResponse, err := mappers.CommandResponseTo(r)
+			if err != nil {
+				return nil, []error{err}
+			}
+
+			mappedCommandResponses = append(mappedCommandResponses, mappedResponse)
 		}
 
 		mappedResponses[i] = mappedCommandResponses

--- a/apps/api-gql/internal/delivery/gql/mappers/commands.go
+++ b/apps/api-gql/internal/delivery/gql/mappers/commands.go
@@ -32,10 +32,20 @@ var commandsEntityExpiresAtMap = map[commandwithrelationentity.CommandExpireType
 	commandwithrelationentity.CommandExpireTypeDisable: gqlmodel.CommandExpiresTypeDisable,
 }
 
-func CommandEntityTo(e commandwithrelationentity.CommandWithGroupAndResponses) gqlmodel.Command {
+func CommandEntityTo(e commandwithrelationentity.CommandWithGroupAndResponses) (gqlmodel.Command, error) {
 	rolesIds := make([]string, len(e.Command.RolesIDS))
 	for i, v := range e.Command.RolesIDS {
 		rolesIds[i] = v.String()
+	}
+
+	platforms := make([]gqlmodel.Platform, 0, len(e.Command.Platforms))
+	for _, p := range e.Command.Platforms {
+		mappedPlatform, err := EntityPlatformToGraphQL(p)
+		if err != nil {
+			return gqlmodel.Command{}, fmt.Errorf("map command platform: %w", err)
+		}
+
+		platforms = append(platforms, mappedPlatform)
 	}
 
 	m := gqlmodel.Command{
@@ -67,7 +77,7 @@ func CommandEntityTo(e commandwithrelationentity.CommandWithGroupAndResponses) g
 		ExpiresAt:                 nil, // will be set later
 		ExpiresType:               nil, // will be set later
 		RoleCooldowns:             nil, // will be set later
-		Platforms:                 PlatformsToStrings(e.Command.Platforms),
+		Platforms:                 platforms,
 	}
 
 	if e.Command.Cooldown != nil {
@@ -106,7 +116,7 @@ func CommandEntityTo(e commandwithrelationentity.CommandWithGroupAndResponses) g
 	}
 	m.RoleCooldowns = rolesCooldowns
 
-	return m
+	return m, nil
 }
 
 func CommandGroupTo(e commandwithrelationentity.CommandGroup) gqlmodel.CommandGroup {
@@ -189,6 +199,11 @@ func CommandGqlInputToService(
 		)
 	}
 
+	commandPlatforms, err := GraphQLPlatformsToEntities(input.Platforms.Value())
+	if err != nil {
+		return commands.CreateInput{}, fmt.Errorf("map command platforms: %w", err)
+	}
+
 	return commands.CreateInput{
 		ChannelID:                 channelID,
 		ActorID:                   actorID,
@@ -214,7 +229,7 @@ func CommandGqlInputToService(
 		ExpiresType:               expiresType,
 		Responses:                 responses,
 		RoleCooldowns:             roleCooldowns,
-		Platforms:                 StringsToPlatforms(input.Platforms.Value()),
+		Platforms:                 commandPlatforms,
 	}, nil
 }
 

--- a/apps/api-gql/internal/delivery/gql/mappers/commands.go
+++ b/apps/api-gql/internal/delivery/gql/mappers/commands.go
@@ -123,6 +123,7 @@ func CommandResponseTo(e commandwithrelationentity.CommandResponse) gqlmodel.Com
 		TwitchCategoriesIds: e.TwitchCategoryIDs,
 		OnlineOnly:          e.OnlineOnly,
 		OfflineOnly:         e.OfflineOnly,
+		Platforms:           PlatformsToStrings(e.Platforms),
 	}
 
 	if e.Text != nil {
@@ -144,6 +145,7 @@ func CommandGqlInputToService(
 			TwitchCategoryIDs: res.TwitchCategoriesIds,
 			OnlineOnly:        res.OnlineOnly,
 			OfflineOnly:       res.OfflineOnly,
+			Platforms:         StringsToPlatforms(res.Platforms.Value()),
 		}
 	}
 

--- a/apps/api-gql/internal/delivery/gql/mappers/commands.go
+++ b/apps/api-gql/internal/delivery/gql/mappers/commands.go
@@ -1,6 +1,8 @@
 package mappers
 
 import (
+	"fmt"
+
 	"github.com/google/uuid"
 	"github.com/samber/lo"
 	"github.com/twirapp/twir/apps/api-gql/internal/delivery/gql/gqlmodel"
@@ -115,7 +117,17 @@ func CommandGroupTo(e commandwithrelationentity.CommandGroup) gqlmodel.CommandGr
 	}
 }
 
-func CommandResponseTo(e commandwithrelationentity.CommandResponse) gqlmodel.CommandResponse {
+func CommandResponseTo(e commandwithrelationentity.CommandResponse) (gqlmodel.CommandResponse, error) {
+	platforms := make([]gqlmodel.Platform, 0, len(e.Platforms))
+	for _, p := range e.Platforms {
+		mappedPlatform, err := EntityPlatformToGraphQL(p)
+		if err != nil {
+			return gqlmodel.CommandResponse{}, fmt.Errorf("map response platform: %w", err)
+		}
+
+		platforms = append(platforms, mappedPlatform)
+	}
+
 	m := gqlmodel.CommandResponse{
 		ID:                  e.ID,
 		CommandID:           e.CommandID.String(),
@@ -123,29 +135,34 @@ func CommandResponseTo(e commandwithrelationentity.CommandResponse) gqlmodel.Com
 		TwitchCategoriesIds: e.TwitchCategoryIDs,
 		OnlineOnly:          e.OnlineOnly,
 		OfflineOnly:         e.OfflineOnly,
-		Platforms:           PlatformsToStrings(e.Platforms),
+		Platforms:           platforms,
 	}
 
 	if e.Text != nil {
 		m.Text = *e.Text
 	}
 
-	return m
+	return m, nil
 }
 
 func CommandGqlInputToService(
 	channelID, actorID string,
 	input gqlmodel.CommandsCreateOpts,
-) commands.CreateInput {
+) (commands.CreateInput, error) {
 	responses := make([]commands.CreateInputResponse, len(input.Responses))
 	for idx, res := range input.Responses {
+		platforms, err := GraphQLPlatformsToEntities(res.Platforms.Value())
+		if err != nil {
+			return commands.CreateInput{}, fmt.Errorf("map response platforms: %w", err)
+		}
+
 		responses[idx] = commands.CreateInputResponse{
 			Text:              &res.Text,
 			Order:             idx,
 			TwitchCategoryIDs: res.TwitchCategoriesIds,
 			OnlineOnly:        res.OnlineOnly,
 			OfflineOnly:       res.OfflineOnly,
-			Platforms:         StringsToPlatforms(res.Platforms.Value()),
+			Platforms:         platforms,
 		}
 	}
 
@@ -198,7 +215,7 @@ func CommandGqlInputToService(
 		Responses:                 responses,
 		RoleCooldowns:             roleCooldowns,
 		Platforms:                 StringsToPlatforms(input.Platforms.Value()),
-	}
+	}, nil
 }
 
 func StreamElementsCommandToGql(m streamelements.Command) gqlmodel.StreamElementsCommand {

--- a/apps/api-gql/internal/delivery/gql/mappers/events.go
+++ b/apps/api-gql/internal/delivery/gql/mappers/events.go
@@ -1,11 +1,23 @@
 package mappers
 
 import (
+	"fmt"
+
 	"github.com/twirapp/twir/apps/api-gql/internal/delivery/gql/gqlmodel"
 	"github.com/twirapp/twir/apps/api-gql/internal/entity"
 )
 
-func MapEventToGQL(event entity.Event) gqlmodel.Event {
+func MapEventToGQL(event entity.Event) (gqlmodel.Event, error) {
+	platforms := make([]gqlmodel.Platform, 0, len(event.Platforms))
+	for _, p := range event.Platforms {
+		mappedPlatform, err := EntityPlatformToGraphQL(p)
+		if err != nil {
+			return gqlmodel.Event{}, fmt.Errorf("map event platform: %w", err)
+		}
+
+		platforms = append(platforms, mappedPlatform)
+	}
+
 	operations := make([]gqlmodel.EventOperation, 0, len(event.Operations))
 	for _, op := range event.Operations {
 		filters := make([]gqlmodel.EventOperationFilter, 0, len(op.Filters))
@@ -40,7 +52,7 @@ func MapEventToGQL(event entity.Event) gqlmodel.Event {
 	return gqlmodel.Event{
 		ID:          event.ID,
 		ChannelID:   event.ChannelID,
-		Platforms:   PlatformsToStrings(event.Platforms),
+		Platforms:   platforms,
 		Type:        gqlmodel.EventType(event.Type),
 		RewardID:    event.RewardID,
 		CommandID:   event.CommandID,
@@ -49,5 +61,5 @@ func MapEventToGQL(event entity.Event) gqlmodel.Event {
 		Enabled:     event.Enabled,
 		OnlineOnly:  event.OnlineOnly,
 		Operations:  operations,
-	}
+	}, nil
 }

--- a/apps/api-gql/internal/delivery/gql/mappers/keywords.go
+++ b/apps/api-gql/internal/delivery/gql/mappers/keywords.go
@@ -1,11 +1,23 @@
 package mappers
 
 import (
+	"fmt"
+
 	"github.com/twirapp/twir/apps/api-gql/internal/delivery/gql/gqlmodel"
 	"github.com/twirapp/twir/apps/api-gql/internal/entity"
 )
 
-func KeywordsFrom(k entity.Keyword) gqlmodel.Keyword {
+func KeywordsFrom(k entity.Keyword) (gqlmodel.Keyword, error) {
+	platforms := make([]gqlmodel.Platform, 0, len(k.Platforms))
+	for _, p := range k.Platforms {
+		mappedPlatform, err := EntityPlatformToGraphQL(p)
+		if err != nil {
+			return gqlmodel.Keyword{}, fmt.Errorf("map keyword platform: %w", err)
+		}
+
+		platforms = append(platforms, mappedPlatform)
+	}
+
 	return gqlmodel.Keyword{
 		ID:                  k.ID,
 		Text:                k.Text,
@@ -16,6 +28,6 @@ func KeywordsFrom(k entity.Keyword) gqlmodel.Keyword {
 		IsRegularExpression: k.IsRegular,
 		UsageCount:          k.Usages,
 		RolesIds:            k.RolesIDs,
-		Platforms:           PlatformsToStrings(k.Platforms),
-	}
+		Platforms:           platforms,
+	}, nil
 }

--- a/apps/api-gql/internal/delivery/gql/mappers/platform.go
+++ b/apps/api-gql/internal/delivery/gql/mappers/platform.go
@@ -7,28 +7,6 @@ import (
 	platformentity "github.com/twirapp/twir/libs/entities/platform"
 )
 
-func PlatformsToStrings(platforms []platformentity.Platform) []string {
-	if platforms == nil {
-		return []string{}
-	}
-	result := make([]string, len(platforms))
-	for i, p := range platforms {
-		result[i] = p.String()
-	}
-	return result
-}
-
-func StringsToPlatforms(ss []string) []platformentity.Platform {
-	if ss == nil {
-		return []platformentity.Platform{}
-	}
-	result := make([]platformentity.Platform, len(ss))
-	for i, s := range ss {
-		result[i] = platformentity.Platform(s)
-	}
-	return result
-}
-
 func GraphQLPlatformToEntity(platform gqlmodel.Platform) (platformentity.Platform, error) {
 	switch platform {
 	case gqlmodel.PlatformTwitch:

--- a/apps/api-gql/internal/delivery/gql/mappers/timers.go
+++ b/apps/api-gql/internal/delivery/gql/mappers/timers.go
@@ -1,13 +1,25 @@
 package mappers
 
 import (
+	"fmt"
+
 	"github.com/twirapp/twir/apps/api-gql/internal/delivery/gql/gqlmodel"
 	"github.com/twirapp/twir/libs/bus-core/bots"
 	timersentity "github.com/twirapp/twir/libs/entities/timers"
 	"github.com/twirapp/twir/libs/integrations/streamelements"
 )
 
-func TimerEntityToGql(m timersentity.Timer) gqlmodel.Timer {
+func TimerEntityToGql(m timersentity.Timer) (gqlmodel.Timer, error) {
+	platforms := make([]gqlmodel.Platform, 0, len(m.Platforms))
+	for _, p := range m.Platforms {
+		mappedPlatform, err := EntityPlatformToGraphQL(p)
+		if err != nil {
+			return gqlmodel.Timer{}, fmt.Errorf("map timer platform: %w", err)
+		}
+
+		platforms = append(platforms, mappedPlatform)
+	}
+
 	responses := make([]gqlmodel.TimerResponse, 0, len(m.Responses))
 	for _, r := range m.Responses {
 		responses = append(
@@ -31,8 +43,8 @@ func TimerEntityToGql(m timersentity.Timer) gqlmodel.Timer {
 		TimeInterval:    m.TimeInterval,
 		MessageInterval: m.MessageInterval,
 		Responses:       responses,
-		Platforms:       PlatformsToStrings(m.Platforms),
-	}
+		Platforms:       platforms,
+	}, nil
 }
 
 func StreamElementsTimerToGql(m streamelements.Timer) gqlmodel.StreamElementsTimer {

--- a/apps/api-gql/internal/delivery/gql/resolvers/chat-messages.resolver.go
+++ b/apps/api-gql/internal/delivery/gql/resolvers/chat-messages.resolver.go
@@ -19,7 +19,15 @@ import (
 func (r *queryResolver) ChatMessages(ctx context.Context, input gqlmodel.ChatMessageInput) ([]gqlmodel.ChatMessage, error) {
 	var platformFilter []string
 	if input.PlatformIn.IsSet() {
-		platformFilter = input.PlatformIn.Value()
+		platforms, err := mappers.GraphQLPlatformsToEntities(input.PlatformIn.Value())
+		if err != nil {
+			return nil, fmt.Errorf("failed to map platforms filter: %w", err)
+		}
+
+		platformFilter = make([]string, 0, len(platforms))
+		for _, p := range platforms {
+			platformFilter = append(platformFilter, p.String())
+		}
 	}
 
 	targets, err := resolveSelectedDashboardChatMessageTargets(ctx, r.deps, platformFilter)

--- a/apps/api-gql/internal/delivery/gql/resolvers/commands.resolver.go
+++ b/apps/api-gql/internal/delivery/gql/resolvers/commands.resolver.go
@@ -167,6 +167,7 @@ func (r *mutationResolver) CommandsUpdate(ctx context.Context, id uuid.UUID, opt
 					TwitchCategoryIDs: res.TwitchCategoriesIds,
 					OnlineOnly:        res.OnlineOnly,
 					OfflineOnly:       res.OfflineOnly,
+					Platforms:         mappers.StringsToPlatforms(res.Platforms.Value()),
 				},
 			)
 		}

--- a/apps/api-gql/internal/delivery/gql/resolvers/commands.resolver.go
+++ b/apps/api-gql/internal/delivery/gql/resolvers/commands.resolver.go
@@ -78,7 +78,10 @@ func (r *mutationResolver) CommandsCreate(ctx context.Context, opts gqlmodel.Com
 		return nil, gqlerrors.HandleError(err)
 	}
 
-	createInput := mappers.CommandGqlInputToService(dashboardId, user.ID, opts)
+	createInput, err := mappers.CommandGqlInputToService(dashboardId, user.ID, opts)
+	if err != nil {
+		return nil, gqlerrors.HandleError(err)
+	}
 
 	newCmd, err := r.deps.CommandsService.Create(ctx, createInput)
 	if err != nil {
@@ -159,6 +162,11 @@ func (r *mutationResolver) CommandsUpdate(ctx context.Context, id uuid.UUID, opt
 
 	if opts.Responses.IsSet() {
 		for idx, res := range opts.Responses.Value() {
+			platforms, err := mappers.GraphQLPlatformsToEntities(res.Platforms.Value())
+			if err != nil {
+				return false, err
+			}
+
 			updateInput.Responses = append(
 				updateInput.Responses,
 				commands_with_groups_and_responses.UpdateInputResponse{
@@ -167,7 +175,7 @@ func (r *mutationResolver) CommandsUpdate(ctx context.Context, id uuid.UUID, opt
 					TwitchCategoryIDs: res.TwitchCategoriesIds,
 					OnlineOnly:        res.OnlineOnly,
 					OfflineOnly:       res.OfflineOnly,
-					Platforms:         mappers.StringsToPlatforms(res.Platforms.Value()),
+					Platforms:         platforms,
 				},
 			)
 		}
@@ -244,7 +252,10 @@ func (r *mutationResolver) CommandsCreateMultiple(ctx context.Context, commands 
 
 	inputs := make([]commandsservice.CreateInput, 0, len(commands))
 	for _, cmd := range commands {
-		createInput := mappers.CommandGqlInputToService(dashboardId, user.ID, cmd)
+		createInput, err := mappers.CommandGqlInputToService(dashboardId, user.ID, cmd)
+		if err != nil {
+			return false, err
+		}
 
 		inputs = append(inputs, createInput)
 	}

--- a/apps/api-gql/internal/delivery/gql/resolvers/commands.resolver.go
+++ b/apps/api-gql/internal/delivery/gql/resolvers/commands.resolver.go
@@ -198,7 +198,12 @@ func (r *mutationResolver) CommandsUpdate(ctx context.Context, id uuid.UUID, opt
 	}
 
 	if opts.Platforms.IsSet() {
-		updateInput.Platforms = mappers.StringsToPlatforms(opts.Platforms.Value())
+		platforms, err := mappers.GraphQLPlatformsToEntities(opts.Platforms.Value())
+		if err != nil {
+			return false, err
+		}
+
+		updateInput.Platforms = platforms
 	}
 
 	if _, err := r.deps.CommandsWithGroupsAndResponsesService.Update(
@@ -300,7 +305,11 @@ func (r *queryResolver) Commands(ctx context.Context) ([]gqlmodel.Command, error
 
 	converted := make([]gqlmodel.Command, 0, len(cmds))
 	for _, c := range cmds {
-		command := mappers.CommandEntityTo(c)
+		command, err := mappers.CommandEntityTo(c)
+		if err != nil {
+			return nil, err
+		}
+
 		converted = append(converted, command)
 	}
 

--- a/apps/api-gql/internal/delivery/gql/resolvers/events.resolver.go
+++ b/apps/api-gql/internal/delivery/gql/resolvers/events.resolver.go
@@ -53,10 +53,15 @@ func (r *mutationResolver) EventCreate(ctx context.Context, input gqlmodel.Event
 		)
 	}
 
+	platforms, err := mappers.GraphQLPlatformsToEntities(input.Platforms)
+	if err != nil {
+		return nil, gqlerrors.HandleError(err)
+	}
+
 	event, err := r.deps.EventsService.Create(
 		ctx, events.CreateInput{
 			ChannelID:   dashboardID,
-			Platforms:   mappers.StringsToPlatforms(input.Platforms),
+			Platforms:   platforms,
 			Type:        entity.EventType(input.Type),
 			RewardID:    input.RewardID.Value(),
 			CommandID:   input.CommandID.Value(),
@@ -71,7 +76,11 @@ func (r *mutationResolver) EventCreate(ctx context.Context, input gqlmodel.Event
 		return nil, gqlerrors.HandleError(err)
 	}
 
-	converted := mappers.MapEventToGQL(event)
+	converted, err := mappers.MapEventToGQL(event)
+	if err != nil {
+		return nil, gqlerrors.HandleError(err)
+	}
+
 	return &converted, nil
 }
 
@@ -121,7 +130,11 @@ func (r *mutationResolver) EventUpdate(ctx context.Context, id string, input gql
 
 	var convertedPlatforms *[]platform.Platform
 	if input.Platforms.IsSet() {
-		platforms := mappers.StringsToPlatforms(input.Platforms.Value())
+		platforms, err := mappers.GraphQLPlatformsToEntities(input.Platforms.Value())
+		if err != nil {
+			return nil, gqlerrors.HandleError(err)
+		}
+
 		convertedPlatforms = &platforms
 	}
 
@@ -143,7 +156,11 @@ func (r *mutationResolver) EventUpdate(ctx context.Context, id string, input gql
 		return nil, gqlerrors.HandleError(err)
 	}
 
-	converted := mappers.MapEventToGQL(event)
+	converted, err := mappers.MapEventToGQL(event)
+	if err != nil {
+		return nil, gqlerrors.HandleError(err)
+	}
+
 	return &converted, nil
 }
 
@@ -173,7 +190,11 @@ func (r *mutationResolver) EventEnableOrDisable(ctx context.Context, id string, 
 		return nil, gqlerrors.HandleError(err)
 	}
 
-	converted := mappers.MapEventToGQL(event)
+	converted, err := mappers.MapEventToGQL(event)
+	if err != nil {
+		return nil, gqlerrors.HandleError(err)
+	}
+
 	return &converted, nil
 }
 
@@ -191,7 +212,12 @@ func (r *queryResolver) Events(ctx context.Context) ([]gqlmodel.Event, error) {
 
 	result := make([]gqlmodel.Event, 0, len(eventsData))
 	for _, event := range eventsData {
-		result = append(result, mappers.MapEventToGQL(event))
+		converted, err := mappers.MapEventToGQL(event)
+		if err != nil {
+			return nil, gqlerrors.HandleError(err)
+		}
+
+		result = append(result, converted)
 	}
 
 	return result, nil
@@ -204,6 +230,10 @@ func (r *queryResolver) EventByID(ctx context.Context, id string) (*gqlmodel.Eve
 		return nil, gqlerrors.HandleError(err)
 	}
 
-	converted := mappers.MapEventToGQL(event)
+	converted, err := mappers.MapEventToGQL(event)
+	if err != nil {
+		return nil, gqlerrors.HandleError(err)
+	}
+
 	return &converted, nil
 }

--- a/apps/api-gql/internal/delivery/gql/resolvers/keywords.resolver.go
+++ b/apps/api-gql/internal/delivery/gql/resolvers/keywords.resolver.go
@@ -62,7 +62,12 @@ func (r *mutationResolver) KeywordCreate(ctx context.Context, opts gqlmodel.Keyw
 	}
 
 	if opts.Platforms.IsSet() {
-		input.Platforms = mappers.StringsToPlatforms(opts.Platforms.Value())
+		platforms, err := mappers.GraphQLPlatformsToEntities(opts.Platforms.Value())
+		if err != nil {
+			return nil, gqlerrors.HandleError(err)
+		}
+
+		input.Platforms = platforms
 	}
 
 	k, err := r.deps.KeywordsService.Create(ctx, input)
@@ -70,7 +75,11 @@ func (r *mutationResolver) KeywordCreate(ctx context.Context, opts gqlmodel.Keyw
 		return nil, gqlerrors.HandleError(err)
 	}
 
-	converted := mappers.KeywordsFrom(k)
+	converted, err := mappers.KeywordsFrom(k)
+	if err != nil {
+		return nil, gqlerrors.HandleError(err)
+	}
+
 	return &converted, nil
 }
 
@@ -133,7 +142,12 @@ func (r *mutationResolver) KeywordUpdate(ctx context.Context, id uuid.UUID, opts
 	}
 
 	if opts.Platforms.IsSet() {
-		input.Platforms = mappers.StringsToPlatforms(opts.Platforms.Value())
+		platforms, err := mappers.GraphQLPlatformsToEntities(opts.Platforms.Value())
+		if err != nil {
+			return nil, gqlerrors.HandleError(err)
+		}
+
+		input.Platforms = platforms
 	}
 
 	keyword, err := r.deps.KeywordsService.Update(ctx, input)
@@ -141,7 +155,11 @@ func (r *mutationResolver) KeywordUpdate(ctx context.Context, id uuid.UUID, opts
 		return nil, gqlerrors.HandleError(err)
 	}
 
-	converted := mappers.KeywordsFrom(keyword)
+	converted, err := mappers.KeywordsFrom(keyword)
+	if err != nil {
+		return nil, gqlerrors.HandleError(err)
+	}
+
 	return &converted, nil
 }
 
@@ -178,7 +196,12 @@ func (r *queryResolver) Keywords(ctx context.Context) ([]gqlmodel.Keyword, error
 
 	converted := make([]gqlmodel.Keyword, 0, len(channelKeywords))
 	for _, k := range channelKeywords {
-		converted = append(converted, mappers.KeywordsFrom(k))
+		mapped, err := mappers.KeywordsFrom(k)
+		if err != nil {
+			return nil, gqlerrors.HandleError(err)
+		}
+
+		converted = append(converted, mapped)
 	}
 
 	return converted, nil

--- a/apps/api-gql/internal/delivery/gql/resolvers/timers.resolver.go
+++ b/apps/api-gql/internal/delivery/gql/resolvers/timers.resolver.go
@@ -39,6 +39,11 @@ func (r *mutationResolver) TimersCreate(ctx context.Context, opts gqlmodel.Timer
 			},
 		)
 	}
+	platforms, err := mappers.GraphQLPlatformsToEntities(opts.Platforms.Value())
+	if err != nil {
+		return nil, gqlerrors.HandleError(err)
+	}
+
 	timer, err := r.deps.TimersService.Create(
 		ctx, timers.CreateInput{
 			ChannelID:       dashboardId,
@@ -50,14 +55,18 @@ func (r *mutationResolver) TimersCreate(ctx context.Context, opts gqlmodel.Timer
 			TimeInterval:    opts.TimeInterval,
 			MessageInterval: opts.MessageInterval,
 			Responses:       responses,
-			Platforms:       mappers.StringsToPlatforms(opts.Platforms.Value()),
+			Platforms:       platforms,
 		},
 	)
 	if err != nil {
 		return nil, gqlerrors.HandleError(err)
 	}
 
-	converted := mappers.TimerEntityToGql(timer)
+	converted, err := mappers.TimerEntityToGql(timer)
+	if err != nil {
+		return nil, gqlerrors.HandleError(err)
+	}
+
 	return &converted, nil
 }
 
@@ -88,6 +97,11 @@ func (r *mutationResolver) TimersCreateMany(ctx context.Context, opts []gqlmodel
 			)
 		}
 
+		platforms, err := mappers.GraphQLPlatformsToEntities(opt.Platforms.Value())
+		if err != nil {
+			return false, gqlerrors.HandleError(err)
+		}
+
 		inputs = append(
 			inputs,
 			timers.CreateInput{
@@ -100,7 +114,7 @@ func (r *mutationResolver) TimersCreateMany(ctx context.Context, opts []gqlmodel
 				TimeInterval:    opt.TimeInterval,
 				MessageInterval: opt.MessageInterval,
 				Responses:       responses,
-				Platforms:       mappers.StringsToPlatforms(opt.Platforms.Value()),
+				Platforms:       platforms,
 			},
 		)
 	}
@@ -137,6 +151,11 @@ func (r *mutationResolver) TimersUpdate(ctx context.Context, id uuid.UUID, opts 
 		)
 	}
 
+	platforms, err := mappers.GraphQLPlatformsToEntities(opts.Platforms.Value())
+	if err != nil {
+		return nil, gqlerrors.HandleError(err)
+	}
+
 	timer, err := r.deps.TimersService.Update(
 		ctx,
 		timers.UpdateInput{
@@ -150,14 +169,18 @@ func (r *mutationResolver) TimersUpdate(ctx context.Context, id uuid.UUID, opts 
 			TimeInterval:    opts.TimeInterval.Value(),
 			MessageInterval: opts.MessageInterval.Value(),
 			Responses:       responses,
-			Platforms:       mappers.StringsToPlatforms(opts.Platforms.Value()),
+			Platforms:       platforms,
 		},
 	)
 	if err != nil {
 		return nil, gqlerrors.HandleError(err)
 	}
 
-	converted := mappers.TimerEntityToGql(timer)
+	converted, err := mappers.TimerEntityToGql(timer)
+	if err != nil {
+		return nil, gqlerrors.HandleError(err)
+	}
+
 	return &converted, nil
 }
 
@@ -195,7 +218,12 @@ func (r *queryResolver) Timers(ctx context.Context) ([]gqlmodel.Timer, error) {
 
 	converted := make([]gqlmodel.Timer, 0, len(channelTimers))
 	for _, timer := range channelTimers {
-		converted = append(converted, mappers.TimerEntityToGql(timer))
+		mapped, err := mappers.TimerEntityToGql(timer)
+		if err != nil {
+			return nil, gqlerrors.HandleError(err)
+		}
+
+		converted = append(converted, mapped)
 	}
 
 	return converted, nil

--- a/apps/api-gql/internal/delivery/gql/schema/chat-messages.graphql
+++ b/apps/api-gql/internal/delivery/gql/schema/chat-messages.graphql
@@ -9,7 +9,7 @@ extend type Subscription {
 }
 
 input ChatMessageInput {
-	platformIn: [String!]
+	platformIn: [Platform!]
 	userIdIn: [String!]
 	userNameLike: String @validate(constraint: "max=40")
 	textLike: String @validate(constraint: "max=500")

--- a/apps/api-gql/internal/delivery/gql/schema/commands.graphql
+++ b/apps/api-gql/internal/delivery/gql/schema/commands.graphql
@@ -65,7 +65,7 @@ type CommandResponse {
   twitchCategories: [TwitchCategory!]! @goField(forceResolver: true)
   onlineOnly: Boolean!
   offlineOnly: Boolean!
-  platforms: [String!]!
+  platforms: [Platform!]!
 }
 
 type CommandRoleCooldown {
@@ -157,7 +157,7 @@ input CreateOrUpdateCommandResponseInput {
   twitchCategoriesIds: [String!]! @validate(constraint: "max=500")
   onlineOnly: Boolean!
   offlineOnly: Boolean!
-  platforms: [String!]
+  platforms: [Platform!]
 }
 
 input CommandRoleCooldownInput {

--- a/apps/api-gql/internal/delivery/gql/schema/commands.graphql
+++ b/apps/api-gql/internal/delivery/gql/schema/commands.graphql
@@ -65,6 +65,7 @@ type CommandResponse {
   twitchCategories: [TwitchCategory!]! @goField(forceResolver: true)
   onlineOnly: Boolean!
   offlineOnly: Boolean!
+  platforms: [String!]!
 }
 
 type CommandRoleCooldown {
@@ -156,6 +157,7 @@ input CreateOrUpdateCommandResponseInput {
   twitchCategoriesIds: [String!]! @validate(constraint: "max=500")
   onlineOnly: Boolean!
   offlineOnly: Boolean!
+  platforms: [String!]
 }
 
 input CommandRoleCooldownInput {

--- a/apps/api-gql/internal/delivery/gql/schema/commands.graphql
+++ b/apps/api-gql/internal/delivery/gql/schema/commands.graphql
@@ -54,7 +54,7 @@ type Command {
   expiresAt: Int
   expiresType: CommandExpiresType
   roleCooldowns: [CommandRoleCooldown!]!
-  platforms: [String!]!
+  platforms: [Platform!]!
 }
 
 type CommandResponse {
@@ -119,7 +119,7 @@ input CommandsCreateOpts {
   expiresType: CommandExpiresType
   roleCooldowns: [CommandRoleCooldownInput!]!
     @validate(constraint: "dive,max=500")
-  platforms: [String!]
+  platforms: [Platform!]
 }
 
 input CommandsUpdateOpts {
@@ -149,7 +149,7 @@ input CommandsUpdateOpts {
   offlineOnly: Boolean
   roleCooldowns: [CommandRoleCooldownInput!]
     @validate(constraint: "dive,omitempty")
-  platforms: [String!]
+  platforms: [Platform!]
 }
 
 input CreateOrUpdateCommandResponseInput {

--- a/apps/api-gql/internal/delivery/gql/schema/events.graphql
+++ b/apps/api-gql/internal/delivery/gql/schema/events.graphql
@@ -115,7 +115,7 @@ enum EventType {
 type Event {
 	id: String!
 	channelId: String!
-	platforms: [String!]!
+	platforms: [Platform!]!
 	type: EventType!
 	rewardId: String
 	commandId: String
@@ -148,7 +148,7 @@ type EventOperationFilter {
 }
 
 input EventCreateInput {
-	platforms: [String!]!
+	platforms: [Platform!]!
 	type: EventType! @validate(constraint: "required")
 	rewardId: String @validate(constraint: "uuid,omitempty")
 	commandId: String @validate(constraint: "uuid,omitempty")
@@ -160,7 +160,7 @@ input EventCreateInput {
 }
 
 input EventUpdateInput {
-	platforms: [String!]
+	platforms: [Platform!]
 	type: EventType
 	rewardId: String @validate(constraint: "uuid,omitempty")
 	commandId: String @validate(constraint: "uuid,omitempty")

--- a/apps/api-gql/internal/delivery/gql/schema/keywords.graphql
+++ b/apps/api-gql/internal/delivery/gql/schema/keywords.graphql
@@ -18,7 +18,7 @@ type Keyword {
 	isRegularExpression: Boolean!
 	usageCount: Int!
 	rolesIds: [UUID!]!
-	platforms: [String!]!
+	platforms: [Platform!]!
 }
 
 input KeywordCreateInput {
@@ -30,7 +30,7 @@ input KeywordCreateInput {
 	isRegularExpression: Boolean
 	isReply: Boolean
 	rolesIds: [UUID!]
-	platforms: [String!]
+	platforms: [Platform!]
 }
 
 input KeywordUpdateInput {
@@ -42,5 +42,5 @@ input KeywordUpdateInput {
 	isRegularExpression: Boolean
 	isReply: Boolean
 	rolesIds: [UUID!]
-	platforms: [String!]
+	platforms: [Platform!]
 }

--- a/apps/api-gql/internal/delivery/gql/schema/timers.graphql
+++ b/apps/api-gql/internal/delivery/gql/schema/timers.graphql
@@ -18,7 +18,7 @@ type Timer {
 	timeInterval: Int!
 	messageInterval: Int!
 	responses: [TimerResponse!]!
-	platforms: [String!]!
+	platforms: [Platform!]!
 }
 
 type TimerResponse {
@@ -37,7 +37,7 @@ input TimerCreateInput {
 	timeInterval: Int! @validate(constraint: "min=0,max=999999")
 	messageInterval: Int! @validate(constraint: "min=0,max=999999")
 	responses: [TimerResponseCreateInput!]!
-	platforms: [String!]
+	platforms: [Platform!]
 }
 
 input TimerResponseCreateInput {
@@ -55,7 +55,7 @@ input TimerUpdateInput {
 	timeInterval: Int @validate(constraint: "min=1,max=999999")
 	messageInterval: Int @validate(constraint: "min=0,max=999999")
 	responses: [TimerResponseUpdateInput!]
-	platforms: [String!]
+	platforms: [Platform!]
 }
 
 input TimerResponseUpdateInput {

--- a/apps/api-gql/internal/services/commands/create.go
+++ b/apps/api-gql/internal/services/commands/create.go
@@ -53,6 +53,7 @@ type CreateInputResponse struct {
 	TwitchCategoryIDs []string
 	OnlineOnly        bool
 	OfflineOnly       bool
+	Platforms         []platform.Platform
 }
 
 type CreateInputRoleCooldown struct {
@@ -166,6 +167,7 @@ func (c *Service) Create(ctx context.Context, input CreateInput) (commandwithrel
 						TwitchCategoryIDs: response.TwitchCategoryIDs,
 						OnlineOnly:        response.OnlineOnly,
 						OfflineOnly:       response.OfflineOnly,
+						Platforms:         response.Platforms,
 					},
 				)
 				if err != nil {

--- a/apps/api-gql/internal/services/commands_responses/commands_responses.go
+++ b/apps/api-gql/internal/services/commands_responses/commands_responses.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/google/uuid"
 	commandwithrelationentity "github.com/twirapp/twir/libs/entities/command_with_relations"
+	"github.com/twirapp/twir/libs/entities/platform"
 	"github.com/twirapp/twir/libs/repositories/commands_response"
 	"github.com/twirapp/twir/libs/repositories/commands_response/model"
 	"go.uber.org/fx"
@@ -34,6 +35,7 @@ func (c *Service) modelToEntity(dbResponse model.Response) commandwithrelationen
 		TwitchCategoryIDs: dbResponse.TwitchCategoryIDs,
 		OnlineOnly:        dbResponse.OnlineOnly,
 		OfflineOnly:       dbResponse.OfflineOnly,
+		Platforms:         dbResponse.Platforms,
 	}
 }
 
@@ -68,6 +70,7 @@ type CreateInput struct {
 	TwitchCategoryIDs []string
 	OnlineOnly        bool
 	OfflineOnly       bool
+	Platforms         []platform.Platform
 }
 
 func (c *Service) Create(ctx context.Context, input CreateInput) (
@@ -83,6 +86,7 @@ func (c *Service) Create(ctx context.Context, input CreateInput) (
 			TwitchCategoryIDs: input.TwitchCategoryIDs,
 			OnlineOnly:        input.OnlineOnly,
 			OfflineOnly:       input.OfflineOnly,
+			Platforms:         input.Platforms,
 		},
 	)
 	if err != nil {

--- a/apps/api-gql/internal/services/commands_with_groups_and_responses/commands_with_groups_and_responses.go
+++ b/apps/api-gql/internal/services/commands_with_groups_and_responses/commands_with_groups_and_responses.go
@@ -120,6 +120,7 @@ func (c *Service) mapToEntity(
 				TwitchCategoryIDs: r.TwitchCategoryIDs,
 				OnlineOnly:        r.OnlineOnly,
 				OfflineOnly:       r.OfflineOnly,
+				Platforms:         r.Platforms,
 			},
 		)
 	}

--- a/apps/api-gql/internal/services/commands_with_groups_and_responses/update.go
+++ b/apps/api-gql/internal/services/commands_with_groups_and_responses/update.go
@@ -57,6 +57,7 @@ type UpdateInputResponse struct {
 	TwitchCategoryIDs []string
 	OnlineOnly        bool
 	OfflineOnly       bool
+	Platforms         []platform.Platform
 }
 
 type UpdateInputRoleCooldown struct {
@@ -182,6 +183,7 @@ func (c *Service) Update(
 							TwitchCategoryIDs: r.TwitchCategoryIDs,
 							OnlineOnly:        r.OnlineOnly,
 							OfflineOnly:       r.OfflineOnly,
+							Platforms:         r.Platforms,
 						},
 					)
 					if err != nil {

--- a/apps/parser/internal/commands/commands.go
+++ b/apps/parser/internal/commands/commands.go
@@ -477,6 +477,10 @@ func (c *Commands) ParseCommandResponses(
 				continue
 			}
 
+			if !platformentity.ShouldExecute(r.Platforms, plat) {
+				continue
+			}
+
 			responsesForCategory = append(responsesForCategory, r)
 		}
 

--- a/libs/entities/command_with_relations/command_with_relation.go
+++ b/libs/entities/command_with_relations/command_with_relation.go
@@ -75,6 +75,7 @@ type CommandResponse struct {
 	TwitchCategoryIDs []string
 	OnlineOnly        bool
 	OfflineOnly       bool
+	Platforms         []platform.Platform
 
 	isNil bool
 }

--- a/libs/migrations/postgres/20260730125512_command_responses_platforms.sql
+++ b/libs/migrations/postgres/20260730125512_command_responses_platforms.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE channels_commands_responses ADD COLUMN platforms platform[] NOT NULL DEFAULT '{}';
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE channels_commands_responses DROP COLUMN IF EXISTS platforms;
+-- +goose StatementEnd

--- a/libs/repositories/commands_response/commands_reponses.go
+++ b/libs/repositories/commands_response/commands_reponses.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/google/uuid"
+	"github.com/twirapp/twir/libs/entities/platform"
 	"github.com/twirapp/twir/libs/repositories/commands_response/model"
 )
 
@@ -22,6 +23,7 @@ type CreateInput struct {
 	TwitchCategoryIDs []string
 	OnlineOnly        bool
 	OfflineOnly       bool
+	Platforms         []platform.Platform
 }
 
 type UpdateInput struct {
@@ -30,4 +32,5 @@ type UpdateInput struct {
 	TwitchCategoryIDs []string
 	OnlineOnly        *bool
 	OfflineOnly       *bool
+	Platforms         []platform.Platform
 }

--- a/libs/repositories/commands_response/model/model.go
+++ b/libs/repositories/commands_response/model/model.go
@@ -2,16 +2,18 @@ package model
 
 import (
 	"github.com/google/uuid"
+	"github.com/twirapp/twir/libs/entities/platform"
 )
 
 type Response struct {
-	ID                uuid.UUID `db:"id"                 json:"id"`
-	Text              *string   `db:"text"               json:"text"`
-	CommandID         uuid.UUID `db:"commandId"          json:"commandId"`
-	Order             int       `db:"order"              json:"order"`
-	TwitchCategoryIDs []string  `db:"twitch_category_id" json:"twitch_category_ids"`
-	OnlineOnly        bool      `db:"online_only"        json:"online_only"`
-	OfflineOnly       bool      `db:"offline_only"       json:"offline_only"`
+	ID                uuid.UUID           `db:"id"                 json:"id"`
+	Text              *string             `db:"text"               json:"text"`
+	CommandID         uuid.UUID           `db:"commandId"          json:"commandId"`
+	Order             int                 `db:"order"              json:"order"`
+	TwitchCategoryIDs []string            `db:"twitch_category_id" json:"twitch_category_ids"`
+	OnlineOnly        bool                `db:"online_only"        json:"online_only"`
+	OfflineOnly       bool                `db:"offline_only"       json:"offline_only"`
+	Platforms         []platform.Platform `db:"platforms"          json:"platforms"`
 }
 
 var Nil = Response{}

--- a/libs/repositories/commands_response/pgx/pgx.go
+++ b/libs/repositories/commands_response/pgx/pgx.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/twirapp/twir/libs/entities/platform"
 	"github.com/twirapp/twir/libs/repositories"
 	"github.com/twirapp/twir/libs/repositories/commands_response"
 	"github.com/twirapp/twir/libs/repositories/commands_response/model"
@@ -44,9 +45,9 @@ func (c *Pgx) Create(ctx context.Context, input commands_response.CreateInput) (
 	error,
 ) {
 	query := `
-INSERT INTO channels_commands_responses("commandId", "order", text, twitch_category_id, online_only, offline_only)
-VALUES ($1, $2, $3, $4, $5, $6)
-RETURNING id, "commandId", "order", text, twitch_category_id, online_only, offline_only;
+INSERT INTO channels_commands_responses("commandId", "order", text, twitch_category_id, online_only, offline_only, platforms)
+VALUES ($1, $2, $3, $4, $5, $6, $7)
+RETURNING id, "commandId", "order", text, twitch_category_id, online_only, offline_only, platforms;
 `
 
 	conn := c.getter.DefaultTrOrDB(ctx, c.pool)
@@ -59,6 +60,7 @@ RETURNING id, "commandId", "order", text, twitch_category_id, online_only, offli
 		append([]string{}, input.TwitchCategoryIDs...),
 		input.OnlineOnly,
 		input.OfflineOnly,
+		append([]platform.Platform{}, input.Platforms...),
 	)
 	if err != nil {
 		return model.Nil, err
@@ -81,7 +83,7 @@ func (c *Pgx) GetManyByIDs(ctx context.Context, commandsIDs []uuid.UUID) (
 	}
 
 	query := `
-SELECT id, "commandId", "order", text, twitch_category_id, online_only, offline_only
+SELECT id, "commandId", "order", text, twitch_category_id, online_only, offline_only, platforms
 FROM channels_commands_responses
 WHERE "commandId" = any($1);
 `
@@ -138,6 +140,7 @@ func (c *Pgx) Update(
 			`RETURNING id, "commandId", "order", text, twitch_category_id`,
 			"online_only",
 			"offline_only",
+			"platforms",
 		)
 	updateBuilder = repositories.SquirrelApplyPatch(
 		updateBuilder,
@@ -147,6 +150,7 @@ func (c *Pgx) Update(
 			"twitch_category_id": input.TwitchCategoryIDs,
 			"online_only":        input.OnlineOnly,
 			"offline_only":       input.OfflineOnly,
+			"platforms":          input.Platforms,
 		},
 	)
 

--- a/libs/repositories/commands_with_groups_and_responses/pgx/pgx.go
+++ b/libs/repositories/commands_with_groups_and_responses/pgx/pgx.go
@@ -54,13 +54,14 @@ func init() {
 		columns,
 		`
  (SELECT COALESCE(json_agg(json_build_object(
-			 'id', r.id,
-			 'text', r.text,
-			 'commandId', r."commandId",
-			 'order', r."order",
-			 'twitch_category_id', r."twitch_category_id",
-				'online_only', r."online_only",
-				'offline_only', r."offline_only"
+		 'id', r.id,
+		 'text', r.text,
+		 'commandId', r."commandId",
+		 'order', r."order",
+		 'twitch_category_id', r."twitch_category_id",
+			'online_only', r."online_only",
+			'offline_only', r."offline_only",
+			'platforms', r."platforms"
 )), '[]'::json)
 FROM channels_commands_responses r
 WHERE r."commandId" = c.id) as responses

--- a/web/layers/dashboard/api/commands/commands.ts
+++ b/web/layers/dashboard/api/commands/commands.ts
@@ -33,6 +33,7 @@ export const useCommandsApi = createGlobalState(() => {
 							}
 							onlineOnly
 							offlineOnly
+							platforms
 						}
 						cooldown
 						cooldownType

--- a/web/layers/dashboard/components/platform-selector.spec.ts
+++ b/web/layers/dashboard/components/platform-selector.spec.ts
@@ -5,9 +5,9 @@ import { Platform } from '~/gql/graphql.js'
 
 import PlatformSelector from './platform-selector.vue'
 
-const vkPlatformId = Platform.VkVideoLive.toLowerCase()
+const vkPlatformId = Platform.VkVideoLive
 
-function mountSelector(props: { modelValue?: string[]; exclude?: string[] } = {}) {
+function mountSelector(props: { modelValue?: Platform[]; exclude?: Platform[] } = {}) {
 	return mount(PlatformSelector, {
 		props: {
 			modelValue: props.modelValue ?? [],
@@ -59,7 +59,7 @@ describe('PlatformSelector', () => {
 		const vkButton = wrapper.findAll('button').find((button) => button.text().includes('VK Video Live'))!
 		await vkButton.trigger('click')
 
-		// Then the model update carries the generated VK platform constant, lowercased for the wire
+		// Then the model update carries the VK platform enum value
 		const emitted = wrapper.emitted('update:modelValue')
 		expect(emitted).toBeDefined()
 		expect(emitted![0]).toEqual([[vkPlatformId]])

--- a/web/layers/dashboard/components/platform-selector.vue
+++ b/web/layers/dashboard/components/platform-selector.vue
@@ -3,39 +3,39 @@ import { Platform } from '~/gql/graphql.js'
 
 const props = withDefaults(
 	defineProps<{
-		exclude?: string[]
+		exclude?: Platform[]
 	}>(),
 	{
 		exclude: () => [],
 	},
 )
 
-const platforms = defineModel<string[]>({ default: () => [] })
+const platforms = defineModel<Platform[]>({ default: () => [] })
 
 const options = [
 	{
-		id: 'twitch',
+		id: Platform.Twitch,
 		label: 'Twitch',
 		icon: 'simple-icons:twitch',
 		colorClass:
 			'data-[active=true]:border-[#9146FF] data-[active=true]:bg-[#9146FF]/10 data-[active=true]:text-[#9146FF]',
 	},
 	{
-		id: 'kick',
+		id: Platform.Kick,
 		label: 'Kick',
 		icon: 'simple-icons:kick',
 		colorClass:
 			'data-[active=true]:border-[#53FC18] data-[active=true]:bg-[#53FC18]/10 data-[active=true]:text-[#53FC18]',
 	},
 	{
-		id: Platform.VkVideoLive.toLowerCase(),
+		id: Platform.VkVideoLive,
 		label: 'VK Video Live',
 		icon: 'simple-icons:vk',
 		colorClass:
 			'data-[active=true]:border-[#0077FF] data-[active=true]:bg-[#0077FF]/10 data-[active=true]:text-[#0077FF]',
 	},
 	{
-		id: Platform.Youtube.toLowerCase(),
+		id: Platform.Youtube,
 		label: 'YouTube',
 		icon: 'simple-icons:youtube',
 		colorClass:
@@ -45,7 +45,7 @@ const options = [
 
 const visibleOptions = computed(() => options.filter((opt) => !props.exclude.includes(opt.id)))
 
-function toggle(id: string) {
+function toggle(id: Platform) {
 	const current = new Set(platforms.value)
 	if (current.has(id)) {
 		current.delete(id)

--- a/web/layers/dashboard/features/commands/commands-edit.vue
+++ b/web/layers/dashboard/features/commands/commands-edit.vue
@@ -34,6 +34,7 @@ const { handleSubmit, setValues, values } = useForm({
 				twitchCategoriesIds: [],
 				onlineOnly: false,
 				offlineOnly: false,
+				platforms: [],
 			},
 		],
 		description: '',
@@ -74,6 +75,7 @@ onMounted(async () => {
 					twitchCategoriesIds: [],
 					onlineOnly: r.onlineOnly,
 					offlineOnly: r.offlineOnly,
+					platforms: [],
 				})),
 				aliases: [],
 			}))

--- a/web/layers/dashboard/features/commands/composables/use-command-edit-v2.ts
+++ b/web/layers/dashboard/features/commands/composables/use-command-edit-v2.ts
@@ -57,7 +57,7 @@ export const formSchema = object({
 	groupId: string().nullable().optional().default(null),
 	enabledCategories: array(string()).max(100),
 	module: string().optional(),
-	platforms: array(string()).default([]),
+	platforms: array(nativeEnum(Platform)).default([]),
 }).and(
 	object({
 		expiresAt: number().nullable().optional(),

--- a/web/layers/dashboard/features/commands/composables/use-command-edit-v2.ts
+++ b/web/layers/dashboard/features/commands/composables/use-command-edit-v2.ts
@@ -7,7 +7,7 @@ import { array, boolean, nativeEnum, number, object, string } from 'zod'
 import { type Command, useCommandsApi } from '~~/layers/dashboard/api/commands/commands'
 import { useRoles } from '~~/layers/dashboard/api/roles'
 
-import { CommandExpiresType } from '~/gql/graphql.js'
+import { CommandExpiresType, Platform } from '~/gql/graphql.js'
 
 export const formSchema = object({
 	id: string().optional(),
@@ -27,7 +27,7 @@ export const formSchema = object({
 			twitchCategoriesIds: array(string()).max(100),
 			onlineOnly: boolean(),
 			offlineOnly: boolean(),
-			platforms: array(string()).max(100).default([]),
+			platforms: array(nativeEnum(Platform)).max(100).default([]),
 		})
 	)
 		.max(3)

--- a/web/layers/dashboard/features/commands/composables/use-command-edit-v2.ts
+++ b/web/layers/dashboard/features/commands/composables/use-command-edit-v2.ts
@@ -27,6 +27,7 @@ export const formSchema = object({
 			twitchCategoriesIds: array(string()).max(100),
 			onlineOnly: boolean(),
 			offlineOnly: boolean(),
+			platforms: array(string()).max(100).default([]),
 		})
 	)
 		.max(3)

--- a/web/layers/dashboard/features/commands/ui/form/form-responses.vue
+++ b/web/layers/dashboard/features/commands/ui/form/form-responses.vue
@@ -7,6 +7,8 @@ import PlatformSelector from '~~/layers/dashboard/components/platform-selector.v
 import TwitchCategorySearchShadcnMultiple from '~~/layers/dashboard/components/twitch-category-search-shadcn-multiple.vue'
 import VariableInput from '~~/layers/dashboard/components/variable-input.vue'
 
+import type { Platform } from '~/gql/graphql.js'
+
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -57,6 +59,14 @@ const responseDialogOpened = ref(false)
 const { command } = useCommandEditV2()
 
 const editable = computed(() => !command.value?.default)
+
+function selectorToPlatforms(ids: string[]): Platform[] {
+	return ids.map((id) => id.toUpperCase() as Platform)
+}
+
+function platformsToSelectorIds(platforms: Platform[] | undefined): string[] {
+	return (platforms ?? []).map((p) => p.toLowerCase())
+}
 </script>
 
 <template>
@@ -180,15 +190,15 @@ const editable = computed(() => !command.value?.default)
 								</FormField>
 
 								<FormField
-									v-slot="{ componentField }"
+									v-slot="{ value, handleChange }"
 									:name="`responses[${index}].platforms`"
 								>
 									<FormItem>
 										<FormLabel> Platforms for response </FormLabel>
 										<FormControl>
 											<PlatformSelector
-												:model-value="componentField.modelValue"
-												@update:model-value="componentField['onUpdate:modelValue']"
+												:model-value="platformsToSelectorIds(value)"
+												@update:model-value="handleChange(selectorToPlatforms($event))"
 											/>
 										</FormControl>
 										<FormMessage />

--- a/web/layers/dashboard/features/commands/ui/form/form-responses.vue
+++ b/web/layers/dashboard/features/commands/ui/form/form-responses.vue
@@ -3,6 +3,7 @@ import { FieldArray, useField } from 'vee-validate'
 import { computed, ref } from 'vue'
 import { VueDraggable } from 'vue-draggable-plus'
 import { useProfile } from '~~/layers/dashboard/api/auth'
+import PlatformSelector from '~~/layers/dashboard/components/platform-selector.vue'
 import TwitchCategorySearchShadcnMultiple from '~~/layers/dashboard/components/twitch-category-search-shadcn-multiple.vue'
 import VariableInput from '~~/layers/dashboard/components/variable-input.vue'
 
@@ -47,7 +48,7 @@ const maxCommandResponses = computed(() => {
 function handlePush() {
 	setValue([
 		...value.value,
-		{ text: '', twitchCategoriesIds: [], onlineOnly: false, offlineOnly: false },
+		{ text: '', twitchCategoriesIds: [], onlineOnly: false, offlineOnly: false, platforms: [] },
 	])
 }
 
@@ -175,6 +176,22 @@ const editable = computed(() => !command.value?.default)
 												@update:model-value="componentField['onUpdate:modelValue']"
 											/>
 										</FormControl>
+									</FormItem>
+								</FormField>
+
+								<FormField
+									v-slot="{ componentField }"
+									:name="`responses[${index}].platforms`"
+								>
+									<FormItem>
+										<FormLabel> Platforms for response </FormLabel>
+										<FormControl>
+											<PlatformSelector
+												:model-value="componentField.modelValue"
+												@update:model-value="componentField['onUpdate:modelValue']"
+											/>
+										</FormControl>
+										<FormMessage />
 									</FormItem>
 								</FormField>
 

--- a/web/layers/dashboard/features/commands/ui/form/form-responses.vue
+++ b/web/layers/dashboard/features/commands/ui/form/form-responses.vue
@@ -7,8 +7,6 @@ import PlatformSelector from '~~/layers/dashboard/components/platform-selector.v
 import TwitchCategorySearchShadcnMultiple from '~~/layers/dashboard/components/twitch-category-search-shadcn-multiple.vue'
 import VariableInput from '~~/layers/dashboard/components/variable-input.vue'
 
-import type { Platform } from '~/gql/graphql.js'
-
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -59,14 +57,6 @@ const responseDialogOpened = ref(false)
 const { command } = useCommandEditV2()
 
 const editable = computed(() => !command.value?.default)
-
-function selectorToPlatforms(ids: string[]): Platform[] {
-	return ids.map((id) => id.toUpperCase() as Platform)
-}
-
-function platformsToSelectorIds(platforms: Platform[] | undefined): string[] {
-	return (platforms ?? []).map((p) => p.toLowerCase())
-}
 </script>
 
 <template>
@@ -190,15 +180,15 @@ function platformsToSelectorIds(platforms: Platform[] | undefined): string[] {
 								</FormField>
 
 								<FormField
-									v-slot="{ value, handleChange }"
+									v-slot="{ componentField }"
 									:name="`responses[${index}].platforms`"
 								>
 									<FormItem>
 										<FormLabel> Platforms for response </FormLabel>
 										<FormControl>
 											<PlatformSelector
-												:model-value="platformsToSelectorIds(value)"
-												@update:model-value="handleChange(selectorToPlatforms($event))"
+												:model-value="componentField.modelValue"
+												@update:model-value="componentField['onUpdate:modelValue']"
 											/>
 										</FormControl>
 										<FormMessage />

--- a/web/layers/dashboard/features/community-chat-messages/composables/use-filters.ts
+++ b/web/layers/dashboard/features/community-chat-messages/composables/use-filters.ts
@@ -1,7 +1,7 @@
 import { createGlobalState, refDebounced } from '@vueuse/core'
 import { computed, ref } from 'vue'
 
-import type { ChatMessageInput } from '~/gql/graphql.js'
+import type { ChatMessageInput, Platform } from '~/gql/graphql.js'
 
 export const useChatMessagesFilters = createGlobalState(() => {
 	const userSearchInput = ref('')
@@ -10,7 +10,7 @@ export const useChatMessagesFilters = createGlobalState(() => {
 	const textSearchInput = ref('')
 	const debouncedTextSearchInput = refDebounced(textSearchInput, 500)
 
-	const platforms = ref<string[]>([])
+	const platforms = ref<Platform[]>([])
 
 	const page = ref(0)
 	const perPage = ref(500)

--- a/web/layers/dashboard/features/events/composables/use-events-table.ts
+++ b/web/layers/dashboard/features/events/composables/use-events-table.ts
@@ -9,15 +9,24 @@ import EventsTableOperations from '~~/layers/dashboard/features/events/ui/events
 
 import { Badge } from '@/components/ui/badge'
 
+import { Platform } from '~/gql/graphql.js'
+
 import EventsTableActions from '../ui/events-table-actions.vue'
 
-function getPlatformBadges(platforms: string[]) {
+const platformLabels: Record<Platform, string> = {
+	[Platform.Twitch]: 'Twitch',
+	[Platform.Kick]: 'Kick',
+	[Platform.VkVideoLive]: 'VK Video Live',
+	[Platform.Youtube]: 'YouTube',
+}
+
+function getPlatformBadges(platforms: Platform[]) {
 	if (platforms.length === 0) {
 		return [h(Badge, { variant: 'outline' }, () => 'All')]
 	}
 
 	return platforms.map((platform) =>
-		h(Badge, { variant: 'outline' }, () => platform.charAt(0).toUpperCase() + platform.slice(1))
+		h(Badge, { variant: 'outline' }, () => platformLabels[platform] ?? platform)
 	)
 }
 

--- a/web/layers/dashboard/features/events/event-form-schema.ts
+++ b/web/layers/dashboard/features/events/event-form-schema.ts
@@ -1,7 +1,7 @@
 
 import * as z from 'zod';
 
-import { EventOperationType, EventType } from '~/gql/graphql.js';
+import { EventOperationType, EventType, Platform } from '~/gql/graphql.js';
 
 export const eventFormSchema =
 	z
@@ -10,7 +10,7 @@ export const eventFormSchema =
 			description: z.string().min(1).max(20),
 			enabled: z.boolean().default(true),
 			onlineOnly: z.boolean().default(false),
-			platforms: z.array(z.string()).default([]),
+			platforms: z.array(z.nativeEnum(Platform)).default([]),
 			rewardId: z.string().max(50).optional(),
 			commandId: z.string().max(50).optional(),
 			keywordId: z.string().max(50).optional(),

--- a/web/layers/dashboard/features/keywords/ui/keywords-dialog.vue
+++ b/web/layers/dashboard/features/keywords/ui/keywords-dialog.vue
@@ -27,6 +27,8 @@ import { Label } from '@/components/ui/label'
 import { Switch } from '@/components/ui/switch'
 import { Textarea } from '@/components/ui/textarea'
 
+import { Platform } from '~/gql/graphql.js'
+
 const props = defineProps<{
 	keyword?: Omit<KeywordResponse, 'id'> & { id?: string }
 }>()
@@ -50,7 +52,7 @@ const keywordsForm = useForm({
 		usageCount: z.number().min(0).optional(),
 		rolesIds: z.array(z.string()).optional(),
 		enabled: z.boolean().optional().default(true),
-		platforms: z.array(z.string()).default([]),
+		platforms: z.array(z.nativeEnum(Platform)).default([]),
 	}),
 	initialValues: {
 		text: '',

--- a/web/layers/dashboard/features/timers/composables/use-timers-edit.ts
+++ b/web/layers/dashboard/features/timers/composables/use-timers-edit.ts
@@ -4,7 +4,7 @@ import { toast } from 'vue-sonner'
 import { type TypeOf, array, boolean, nativeEnum, number, object, string } from 'zod'
 import { useTimersApi } from '~~/layers/dashboard/api/timers'
 
-import { TwitchAnnounceColor } from '~/gql/graphql.js'
+import { Platform, TwitchAnnounceColor } from '~/gql/graphql.js'
 
 export const formSchema = object({
 	id: string().optional(),
@@ -22,7 +22,7 @@ export const formSchema = object({
 	enabled: boolean().default(true),
 	offlineEnabled: boolean().default(false),
 	onlineEnabled: boolean().default(true),
-	platforms: array(string()).default([]),
+	platforms: array(nativeEnum(Platform)).default([]),
 })
 
 type FormSchema = TypeOf<typeof formSchema>


### PR DESCRIPTION
## Platform binding для ответов команд

Closes #1023

Каждый вариант ответа команды теперь можно привязать к конкретным платформам (Twitch / Kick / VK Video Live / YouTube) — по аналогии с существующими привязками ответа к категории стрима и online/offline. При срабатывании команды парсер выбирает только те ответы, которые привязаны к платформе, с которой пришло сообщение. Пустой список = ответ работает на всех платформах (обратная совместимость, дефолт миграции `'{}'`).

### Изменения

- **Миграция**: `channels_commands_responses.platforms platform[] NOT NULL DEFAULT '{}'`
- **Репозитории**: `commands_response` (model, CreateInput/UpdateInput, pgx INSERT/SELECT/UPDATE/RETURNING) + `platforms` в `json_build_object` агрегации `commands_with_groups_and_responses` (путь кэша парсера)
- **Парсер**: фильтр `platformentity.ShouldExecute(r.Platforms, plat)` в цикле выбора ответов (`ParseCommandResponses`) — тот же хелпер, что используется для платформ команд/таймеров/ключевых слов
- **api-gql**: `CommandResponse.platforms: [Platform!]!` + `platforms: [Platform!]` в `CreateOrUpdateCommandResponseInput`; прокидывание через сервисы, мапперы, резолверы
- **Enum унификация**: все `platforms`-поля схемы переведены со `[String!]` на существующий enum `Platform` — `Command`, `CommandResponse`, `Keyword`, `Timer`, `Event` + фильтр `platformIn` в chat-messages. Удалены хелперы `StringsToPlatforms`/`PlatformsToStrings`, везде используются типобезопасные `GraphQLPlatformsToEntities`/`EntityPlatformToGraphQL` с пробросом ошибок
- **Дашборд**: `PlatformSelector` стал enum-нативным (`Platform[]`, без lowercase-конвертаций), zod-схемы форм на `nativeEnum(Platform)` (команды, ответы команд, таймеры, ключевые слова, события), `PlatformSelector` добавлен в диалог настроек ответа команды
- ⚠️ **Ломающее изменение API**: значения `platforms` теперь `TWITCH`/`KICK`/`VK_VIDEO_LIVE`/`YOUTUBE` вместо lowercase-строк. Внутренний дашборд — единственный потребитель, обновлён в этом PR

### Поведение

- Ответ без привязки (пустой массив) отправляется на любой платформе — текущее поведение сохраняется
- Ответ с привязкой отправляется только когда команда вызвана на одной из выбранных платформ
- Управление командами через чат (`!commands add`) создаёт ответы с дефолтом БД (все платформы)
- Таймеры, исполняющие команды, идут через тот же пайплайн — привязка работает и для них

### Проверки

- `go build`: api-gql, parser, eventsub, scheduler, cache, repositories, entities ✅
- `go test`: api-gql 257 passed (весь пакет), parser 19 passed ✅ (vet-ошибки про non-constant format string — пре-существующие на main)
- `bun run test` (web): 42 passed ✅, в т.ч. обновлённый `platform-selector.spec.ts`
- vue-tsc / `bun lint`: новых ошибок в изменённых файлах нет ✅
- Миграция применена на dev-базе, сериализация `platform[]` в `json_build_object` проверена ✅
- gqlgen + graphql-codegen перегенерированы (обе директории в .gitignore, генерируются при сборке) ✅

### Заметки

- Побочная находка (не исправлял, out of scope): в `commands_response/model` json-тег `twitch_category_ids` не совпадает с ключом `twitch_category_id` в json_agg — похоже, фильтрация ответов по категории в парсере фактически не срабатывает. Для `platforms` ключ и тег совпадают.