### PR TITLE
feat: add platform availability to built-in variables and default commands

### DIFF
--- a/apps/api-gql/internal/delivery/gql/mappers/platform.go
+++ b/apps/api-gql/internal/delivery/gql/mappers/platform.go
@@ -76,3 +76,17 @@ func EntityPlatformToGraphQL(platform platformentity.Platform) (gqlmodel.Platfor
 		return "", fmt.Errorf("unknown entity platform: %s", platform)
 	}
 }
+
+func EntityPlatformsToGraphQL(platforms []platformentity.Platform) []gqlmodel.Platform {
+	result := make([]gqlmodel.Platform, 0, len(platforms))
+	for _, p := range platforms {
+		mapped, err := EntityPlatformToGraphQL(p)
+		if err != nil {
+			continue
+		}
+
+		result = append(result, mapped)
+	}
+
+	return result
+}

--- a/apps/api-gql/internal/delivery/gql/resolvers/commands.resolver.go
+++ b/apps/api-gql/internal/delivery/gql/resolvers/commands.resolver.go
@@ -395,7 +395,7 @@ func (r *queryResolver) CommandsDefault(ctx context.Context) ([]gqlmodel.Default
 				Description: command.Description,
 				Module:      command.Module,
 				Aliases:     append([]string{}, command.Aliases...),
-				Platforms:   mappers.PlatformsToStrings(command.Platforms),
+				Platforms:   mappers.EntityPlatformsToGraphQL(command.Platforms),
 			},
 		)
 	}

--- a/apps/api-gql/internal/delivery/gql/resolvers/commands.resolver.go
+++ b/apps/api-gql/internal/delivery/gql/resolvers/commands.resolver.go
@@ -379,6 +379,30 @@ func (r *queryResolver) CommandsPublic(ctx context.Context, channelID string) ([
 	return convertedCommands, nil
 }
 
+// CommandsDefault is the resolver for the commandsDefault field.
+func (r *queryResolver) CommandsDefault(ctx context.Context) ([]gqlmodel.DefaultCommandInfo, error) {
+	commands, err := r.deps.TwirBus.Parser.GetDefaultCommands.Request(ctx, struct{}{})
+	if err != nil {
+		return nil, fmt.Errorf("cannot get default commands: %w", err)
+	}
+
+	result := make([]gqlmodel.DefaultCommandInfo, 0, len(commands.Data.List))
+	for _, command := range commands.Data.List {
+		result = append(
+			result,
+			gqlmodel.DefaultCommandInfo{
+				Name:        command.Name,
+				Description: command.Description,
+				Module:      command.Module,
+				Aliases:     append([]string{}, command.Aliases...),
+				Platforms:   mappers.PlatformsToStrings(command.Platforms),
+			},
+		)
+	}
+
+	return result, nil
+}
+
 // Command returns graph.CommandResolver implementation.
 func (r *Resolver) Command() graph.CommandResolver { return &commandResolver{r} }
 

--- a/apps/api-gql/internal/delivery/gql/resolvers/variables.resolver.go
+++ b/apps/api-gql/internal/delivery/gql/resolvers/variables.resolver.go
@@ -180,7 +180,7 @@ func (r *queryResolver) VariablesBuiltIn(ctx context.Context) ([]gqlmodel.BuiltI
 				Visible:             v.Visible,
 				CanBeUsedInRegistry: v.CanBeUsedInRegistry,
 				Links:               links,
-				Platforms:           mappers.PlatformsToStrings(v.Platforms),
+				Platforms:           mappers.EntityPlatformsToGraphQL(v.Platforms),
 			},
 		)
 	}

--- a/apps/api-gql/internal/delivery/gql/resolvers/variables.resolver.go
+++ b/apps/api-gql/internal/delivery/gql/resolvers/variables.resolver.go
@@ -180,6 +180,7 @@ func (r *queryResolver) VariablesBuiltIn(ctx context.Context) ([]gqlmodel.BuiltI
 				Visible:             v.Visible,
 				CanBeUsedInRegistry: v.CanBeUsedInRegistry,
 				Links:               links,
+				Platforms:           mappers.PlatformsToStrings(v.Platforms),
 			},
 		)
 	}

--- a/apps/api-gql/internal/delivery/gql/schema/commands.graphql
+++ b/apps/api-gql/internal/delivery/gql/schema/commands.graphql
@@ -98,7 +98,7 @@ type DefaultCommandInfo {
   description: String!
   module: String!
   aliases: [String!]!
-  platforms: [String!]!
+  platforms: [Platform!]!
 }
 
 input CommandsCreateOpts {

--- a/apps/api-gql/internal/delivery/gql/schema/commands.graphql
+++ b/apps/api-gql/internal/delivery/gql/schema/commands.graphql
@@ -4,6 +4,7 @@ extend type Query {
     @hasAccessToSelectedDashboard
     @hasChannelRolesDashboardPermission(permission: VIEW_COMMANDS)
   commandsPublic(channelId: ID!): [PublicCommand!]!
+  commandsDefault: [DefaultCommandInfo!]! @isAuthenticated
 }
 
 extend type Mutation {
@@ -90,6 +91,14 @@ type PublicCommand {
 type PublicCommandPermission {
   name: String!
   type: String!
+}
+
+type DefaultCommandInfo {
+  name: String!
+  description: String!
+  module: String!
+  aliases: [String!]!
+  platforms: [String!]!
 }
 
 input CommandsCreateOpts {

--- a/apps/api-gql/internal/delivery/gql/schema/variables.graphql
+++ b/apps/api-gql/internal/delivery/gql/schema/variables.graphql
@@ -55,6 +55,7 @@ type BuiltInVariable {
 	visible: Boolean!
 	canBeUsedInRegistry: Boolean!
 	links: [BuiltInVariableLink!]!
+	platforms: [String!]!
 }
 
 type BuiltInVariableLink {

--- a/apps/api-gql/internal/delivery/gql/schema/variables.graphql
+++ b/apps/api-gql/internal/delivery/gql/schema/variables.graphql
@@ -55,7 +55,7 @@ type BuiltInVariable {
 	visible: Boolean!
 	canBeUsedInRegistry: Boolean!
 	links: [BuiltInVariableLink!]!
-	platforms: [String!]!
+	platforms: [Platform!]!
 }
 
 type BuiltInVariableLink {

--- a/apps/parser/internal/commands-bus/commands-bus.go
+++ b/apps/parser/internal/commands-bus/commands-bus.go
@@ -152,6 +152,7 @@ func (c *CommandsBus) Subscribe() error {
 						IsReply:            cmd.IsReply,
 						KeepResponsesOrder: cmd.KeepResponsesOrder,
 						Aliases:            cmd.Aliases,
+						Platforms:          cmd.Platforms,
 					},
 				)
 			}

--- a/apps/parser/internal/commands/7tv/copyset.go
+++ b/apps/parser/internal/commands/7tv/copyset.go
@@ -8,6 +8,7 @@ import (
 	command_arguments "github.com/twirapp/twir/apps/parser/internal/command-arguments"
 	"github.com/twirapp/twir/apps/parser/internal/types"
 	"github.com/twirapp/twir/apps/parser/locales"
+	platformentity "github.com/twirapp/twir/libs/entities/platform"
 	model "github.com/twirapp/twir/libs/gomodels"
 	"github.com/twirapp/twir/libs/i18n"
 	seventvintegration "github.com/twirapp/twir/libs/integrations/seventv"
@@ -34,6 +35,7 @@ var CopySet = &types.DefaultCommand{
 		Aliases: []string{},
 		Enabled: false,
 	},
+	Platforms:         []platformentity.Platform{platformentity.PlatformTwitch},
 	SkipToxicityCheck: true,
 	Args: []command_arguments.Arg{
 		command_arguments.String{

--- a/apps/parser/internal/commands/7tv/emote.go
+++ b/apps/parser/internal/commands/7tv/emote.go
@@ -11,6 +11,7 @@ import (
 	"github.com/twirapp/twir/apps/parser/internal/types"
 	"github.com/twirapp/twir/apps/parser/locales"
 	"github.com/twirapp/twir/apps/parser/pkg/helpers"
+	platformentity "github.com/twirapp/twir/libs/entities/platform"
 	model "github.com/twirapp/twir/libs/gomodels"
 	"github.com/twirapp/twir/libs/i18n"
 	seventvintegration "github.com/twirapp/twir/libs/integrations/seventv"
@@ -30,6 +31,7 @@ var EmoteFind = &types.DefaultCommand{
 		Aliases:     []string{},
 		Enabled:     false,
 	},
+	Platforms:         []platformentity.Platform{platformentity.PlatformTwitch},
 	SkipToxicityCheck: true,
 	Args: []command_arguments.Arg{
 		command_arguments.String{

--- a/apps/parser/internal/commands/7tv/emote_add.go
+++ b/apps/parser/internal/commands/7tv/emote_add.go
@@ -8,6 +8,7 @@ import (
 	command_arguments "github.com/twirapp/twir/apps/parser/internal/command-arguments"
 	"github.com/twirapp/twir/apps/parser/internal/types"
 	"github.com/twirapp/twir/apps/parser/locales"
+	platformentity "github.com/twirapp/twir/libs/entities/platform"
 	model "github.com/twirapp/twir/libs/gomodels"
 	"github.com/twirapp/twir/libs/i18n"
 	seventvintegration "github.com/twirapp/twir/libs/integrations/seventv"
@@ -29,6 +30,7 @@ var EmoteAdd = &types.DefaultCommand{
 		Aliases:     []string{},
 		Enabled:     false,
 	},
+	Platforms:         []platformentity.Platform{platformentity.PlatformTwitch},
 	SkipToxicityCheck: true,
 	Args: []command_arguments.Arg{
 		command_arguments.String{

--- a/apps/parser/internal/commands/7tv/emote_copy.go
+++ b/apps/parser/internal/commands/7tv/emote_copy.go
@@ -9,6 +9,7 @@ import (
 	command_arguments "github.com/twirapp/twir/apps/parser/internal/command-arguments"
 	"github.com/twirapp/twir/apps/parser/internal/types"
 	"github.com/twirapp/twir/apps/parser/locales"
+	platformentity "github.com/twirapp/twir/libs/entities/platform"
 	model "github.com/twirapp/twir/libs/gomodels"
 	"github.com/twirapp/twir/libs/i18n"
 	seventvintegration "github.com/twirapp/twir/libs/integrations/seventv"
@@ -34,6 +35,7 @@ var EmoteCopy = &types.DefaultCommand{
 			"7tv yoink",
 		},
 	},
+	Platforms:         []platformentity.Platform{platformentity.PlatformTwitch},
 	SkipToxicityCheck: true,
 	Args: []command_arguments.Arg{
 		command_arguments.String{

--- a/apps/parser/internal/commands/7tv/emote_delete.go
+++ b/apps/parser/internal/commands/7tv/emote_delete.go
@@ -8,6 +8,7 @@ import (
 	command_arguments "github.com/twirapp/twir/apps/parser/internal/command-arguments"
 	"github.com/twirapp/twir/apps/parser/internal/types"
 	"github.com/twirapp/twir/apps/parser/locales"
+	platformentity "github.com/twirapp/twir/libs/entities/platform"
 	model "github.com/twirapp/twir/libs/gomodels"
 	"github.com/twirapp/twir/libs/i18n"
 	seventvintegration "github.com/twirapp/twir/libs/integrations/seventv"
@@ -26,6 +27,7 @@ var EmoteDelete = &types.DefaultCommand{
 		Aliases:     []string{"7tv remove"},
 		Enabled:     false,
 	},
+	Platforms:         []platformentity.Platform{platformentity.PlatformTwitch},
 	SkipToxicityCheck: true,
 	Args: []command_arguments.Arg{
 		command_arguments.String{

--- a/apps/parser/internal/commands/7tv/emote_rename.go
+++ b/apps/parser/internal/commands/7tv/emote_rename.go
@@ -8,6 +8,7 @@ import (
 	command_arguments "github.com/twirapp/twir/apps/parser/internal/command-arguments"
 	"github.com/twirapp/twir/apps/parser/internal/types"
 	"github.com/twirapp/twir/apps/parser/locales"
+	platformentity "github.com/twirapp/twir/libs/entities/platform"
 	model "github.com/twirapp/twir/libs/gomodels"
 	"github.com/twirapp/twir/libs/i18n"
 	seventvintegration "github.com/twirapp/twir/libs/integrations/seventv"
@@ -27,6 +28,7 @@ var EmoteRename = &types.DefaultCommand{
 		Aliases:     []string{},
 		Enabled:     false,
 	},
+	Platforms:         []platformentity.Platform{platformentity.PlatformTwitch},
 	SkipToxicityCheck: true,
 	Args: []command_arguments.Arg{
 		command_arguments.String{

--- a/apps/parser/internal/commands/7tv/profile.go
+++ b/apps/parser/internal/commands/7tv/profile.go
@@ -10,6 +10,7 @@ import (
 	"github.com/twirapp/twir/apps/parser/internal/types"
 	seventvvariables "github.com/twirapp/twir/apps/parser/internal/variables/7tv"
 	"github.com/twirapp/twir/apps/parser/locales"
+	platformentity "github.com/twirapp/twir/libs/entities/platform"
 	model "github.com/twirapp/twir/libs/gomodels"
 	"github.com/twirapp/twir/libs/i18n"
 )
@@ -27,6 +28,7 @@ var Profile = &types.DefaultCommand{
 		Aliases:     []string{},
 		Enabled:     false,
 	},
+	Platforms:         []platformentity.Platform{platformentity.PlatformTwitch},
 	SkipToxicityCheck: true,
 	Args: []command_arguments.Arg{
 		command_arguments.String{

--- a/apps/parser/internal/commands/categories_aliases/add.go
+++ b/apps/parser/internal/commands/categories_aliases/add.go
@@ -8,6 +8,7 @@ import (
 	command_arguments "github.com/twirapp/twir/apps/parser/internal/command-arguments"
 	"github.com/twirapp/twir/apps/parser/internal/types"
 	"github.com/twirapp/twir/apps/parser/locales"
+	platformentity "github.com/twirapp/twir/libs/entities/platform"
 	model "github.com/twirapp/twir/libs/gomodels"
 	"github.com/twirapp/twir/libs/i18n"
 	categoriesaliasesrepository "github.com/twirapp/twir/libs/repositories/channels_categories_aliases"
@@ -28,6 +29,7 @@ var Add = &types.DefaultCommand{
 		Visible: true,
 		IsReply: true,
 	},
+	Platforms: []platformentity.Platform{platformentity.PlatformTwitch},
 	Args: []command_arguments.Arg{
 		command_arguments.String{
 			Name: "alias",

--- a/apps/parser/internal/commands/categories_aliases/list.go
+++ b/apps/parser/internal/commands/categories_aliases/list.go
@@ -11,6 +11,7 @@ import (
 	"github.com/nicklaw5/helix/v2"
 	"github.com/twirapp/twir/apps/parser/internal/types"
 	"github.com/twirapp/twir/apps/parser/locales"
+	platformentity "github.com/twirapp/twir/libs/entities/platform"
 	model "github.com/twirapp/twir/libs/gomodels"
 	"github.com/twirapp/twir/libs/i18n"
 	"github.com/twirapp/twir/libs/twitch"
@@ -28,6 +29,7 @@ var List = &types.DefaultCommand{
 		Visible: true,
 		IsReply: true,
 	},
+	Platforms: []platformentity.Platform{platformentity.PlatformTwitch},
 	Handler: func(ctx context.Context, parseCtx *types.ParseContext) (
 		*types.CommandsHandlerResult,
 		error,

--- a/apps/parser/internal/commands/channel/game/game.go
+++ b/apps/parser/internal/commands/channel/game/game.go
@@ -10,6 +10,7 @@ import (
 	command_arguments "github.com/twirapp/twir/apps/parser/internal/command-arguments"
 	"github.com/twirapp/twir/apps/parser/internal/types"
 	"github.com/twirapp/twir/apps/parser/locales"
+	platformentity "github.com/twirapp/twir/libs/entities/platform"
 	model "github.com/twirapp/twir/libs/gomodels"
 	"github.com/twirapp/twir/libs/i18n"
 	"github.com/twirapp/twir/libs/twitch"
@@ -30,6 +31,7 @@ var SetCommand = &types.DefaultCommand{
 		Visible:     false,
 		RolesIDS:    pq.StringArray{model.ChannelRoleTypeModerator.String()},
 	},
+	Platforms: []platformentity.Platform{platformentity.PlatformTwitch},
 	Args: []command_arguments.Arg{
 		command_arguments.VariadicString{
 			Name: gameArgName,

--- a/apps/parser/internal/commands/channel/title/title.go
+++ b/apps/parser/internal/commands/channel/title/title.go
@@ -11,6 +11,7 @@ import (
 	command_arguments "github.com/twirapp/twir/apps/parser/internal/command-arguments"
 	"github.com/twirapp/twir/apps/parser/internal/types"
 	"github.com/twirapp/twir/apps/parser/locales"
+	platformentity "github.com/twirapp/twir/libs/entities/platform"
 	model "github.com/twirapp/twir/libs/gomodels"
 	"github.com/twirapp/twir/libs/i18n"
 	"github.com/twirapp/twir/libs/twitch"
@@ -29,6 +30,7 @@ var SetCommand = &types.DefaultCommand{
 		Visible:     false,
 		RolesIDS:    pq.StringArray{model.ChannelRoleTypeModerator.String()},
 	},
+	Platforms: []platformentity.Platform{platformentity.PlatformTwitch},
 	Args: []command_arguments.Arg{
 		command_arguments.VariadicString{
 			Name:     titleArgName,

--- a/apps/parser/internal/commands/clip/clip.go
+++ b/apps/parser/internal/commands/clip/clip.go
@@ -11,6 +11,7 @@ import (
 	"github.com/nicklaw5/helix/v2"
 	"github.com/twirapp/twir/apps/parser/internal/types"
 	"github.com/twirapp/twir/apps/parser/locales"
+	platformentity "github.com/twirapp/twir/libs/entities/platform"
 	model "github.com/twirapp/twir/libs/gomodels"
 	"github.com/twirapp/twir/libs/i18n"
 	"github.com/twirapp/twir/libs/twitch"
@@ -27,6 +28,7 @@ var MakeClip = &types.DefaultCommand{
 		Aliases:     []string{},
 		Enabled:     true,
 	},
+	Platforms:         []platformentity.Platform{platformentity.PlatformTwitch},
 	SkipToxicityCheck: true,
 	Handler: func(ctx context.Context, parseCtx *types.ParseContext) (
 		*types.CommandsHandlerResult,

--- a/apps/parser/internal/commands/games/duel.go
+++ b/apps/parser/internal/commands/games/duel.go
@@ -11,6 +11,7 @@ import (
 	command_arguments "github.com/twirapp/twir/apps/parser/internal/command-arguments"
 	"github.com/twirapp/twir/apps/parser/internal/types"
 	"github.com/twirapp/twir/apps/parser/locales"
+	platformentity "github.com/twirapp/twir/libs/entities/platform"
 	model "github.com/twirapp/twir/libs/gomodels"
 	"github.com/twirapp/twir/libs/i18n"
 	"gorm.io/gorm"
@@ -30,6 +31,7 @@ var Duel = &types.DefaultCommand{
 		Enabled:     false,
 		RolesIDS:    pq.StringArray{},
 	},
+	Platforms: []platformentity.Platform{platformentity.PlatformTwitch},
 	Args: []command_arguments.Arg{
 		command_arguments.String{
 			Name: duelTargetArgName,

--- a/apps/parser/internal/commands/games/duel_accept.go
+++ b/apps/parser/internal/commands/games/duel_accept.go
@@ -10,7 +10,7 @@ import (
 	"github.com/lib/pq"
 	"github.com/twirapp/twir/apps/parser/internal/types"
 	"github.com/twirapp/twir/apps/parser/locales"
-	"github.com/twirapp/twir/libs/entities/platform"
+	platformentity "github.com/twirapp/twir/libs/entities/platform"
 	model "github.com/twirapp/twir/libs/gomodels"
 	"github.com/twirapp/twir/libs/i18n"
 	"gorm.io/gorm"
@@ -32,6 +32,7 @@ var DuelAccept = &types.DefaultCommand{
 		Enabled:     false,
 		RolesIDS:    pq.StringArray{},
 	},
+	Platforms: []platformentity.Platform{platformentity.PlatformTwitch},
 	Handler: func(ctx context.Context, parseCtx *types.ParseContext) (
 		*types.CommandsHandlerResult,
 		error,
@@ -76,7 +77,7 @@ var DuelAccept = &types.DefaultCommand{
 				Err:     err,
 			}
 		}
-		twitchBinding, ok := dbChannel.Binding(platform.PlatformTwitch)
+		twitchBinding, ok := dbChannel.Binding(platformentity.PlatformTwitch)
 		if !ok {
 			return nil, &types.CommandHandlerError{
 				Message: i18n.GetCtx(ctx, locales.Translations.Errors.Generic.CannotGetDbChannel),

--- a/apps/parser/internal/commands/marker/marker.go
+++ b/apps/parser/internal/commands/marker/marker.go
@@ -11,6 +11,7 @@ import (
 	command_arguments "github.com/twirapp/twir/apps/parser/internal/command-arguments"
 	"github.com/twirapp/twir/apps/parser/internal/types"
 	"github.com/twirapp/twir/apps/parser/locales"
+	platformentity "github.com/twirapp/twir/libs/entities/platform"
 	model "github.com/twirapp/twir/libs/gomodels"
 	"github.com/twirapp/twir/libs/i18n"
 	"github.com/twirapp/twir/libs/twitch"
@@ -27,6 +28,7 @@ var Marker = &types.DefaultCommand{
 		Aliases:     []string{},
 		Enabled:     true,
 	},
+	Platforms:         []platformentity.Platform{platformentity.PlatformTwitch},
 	SkipToxicityCheck: true,
 	Args: []command_arguments.Arg{
 		command_arguments.String{

--- a/apps/parser/internal/commands/predictions/cancel.go
+++ b/apps/parser/internal/commands/predictions/cancel.go
@@ -9,6 +9,7 @@ import (
 	"github.com/nicklaw5/helix/v2"
 	"github.com/twirapp/twir/apps/parser/internal/types"
 	"github.com/twirapp/twir/apps/parser/locales"
+	platformentity "github.com/twirapp/twir/libs/entities/platform"
 	model "github.com/twirapp/twir/libs/gomodels"
 	"github.com/twirapp/twir/libs/i18n"
 	"github.com/twirapp/twir/libs/twitch"
@@ -22,6 +23,7 @@ var Cancel = &types.DefaultCommand{
 		Module:      "PREDICTIONS",
 		IsReply:     true,
 	},
+	Platforms:         []platformentity.Platform{platformentity.PlatformTwitch},
 	SkipToxicityCheck: true,
 	Handler: func(ctx context.Context, parseCtx *types.ParseContext) (
 		*types.CommandsHandlerResult,

--- a/apps/parser/internal/commands/predictions/lock.go
+++ b/apps/parser/internal/commands/predictions/lock.go
@@ -9,6 +9,7 @@ import (
 	"github.com/nicklaw5/helix/v2"
 	"github.com/twirapp/twir/apps/parser/internal/types"
 	"github.com/twirapp/twir/apps/parser/locales"
+	platformentity "github.com/twirapp/twir/libs/entities/platform"
 	model "github.com/twirapp/twir/libs/gomodels"
 	"github.com/twirapp/twir/libs/i18n"
 	"github.com/twirapp/twir/libs/twitch"
@@ -22,6 +23,7 @@ var Lock = &types.DefaultCommand{
 		Module:      "PREDICTIONS",
 		IsReply:     true,
 	},
+	Platforms:         []platformentity.Platform{platformentity.PlatformTwitch},
 	SkipToxicityCheck: true,
 	Handler: func(ctx context.Context, parseCtx *types.ParseContext) (
 		*types.CommandsHandlerResult,

--- a/apps/parser/internal/commands/predictions/resolve.go
+++ b/apps/parser/internal/commands/predictions/resolve.go
@@ -10,6 +10,7 @@ import (
 	command_arguments "github.com/twirapp/twir/apps/parser/internal/command-arguments"
 	"github.com/twirapp/twir/apps/parser/internal/types"
 	"github.com/twirapp/twir/apps/parser/locales"
+	platformentity "github.com/twirapp/twir/libs/entities/platform"
 	model "github.com/twirapp/twir/libs/gomodels"
 	"github.com/twirapp/twir/libs/i18n"
 	"github.com/twirapp/twir/libs/twitch"
@@ -27,6 +28,7 @@ var Resolve = &types.DefaultCommand{
 		Module:      "PREDICTIONS",
 		IsReply:     true,
 	},
+	Platforms:         []platformentity.Platform{platformentity.PlatformTwitch},
 	SkipToxicityCheck: true,
 	Args: []command_arguments.Arg{
 		command_arguments.Int{

--- a/apps/parser/internal/commands/predictions/start.go
+++ b/apps/parser/internal/commands/predictions/start.go
@@ -11,6 +11,7 @@ import (
 	command_arguments "github.com/twirapp/twir/apps/parser/internal/command-arguments"
 	"github.com/twirapp/twir/apps/parser/internal/types"
 	"github.com/twirapp/twir/apps/parser/locales"
+	platformentity "github.com/twirapp/twir/libs/entities/platform"
 	model "github.com/twirapp/twir/libs/gomodels"
 	"github.com/twirapp/twir/libs/i18n"
 	"github.com/twirapp/twir/libs/twitch"
@@ -30,6 +31,7 @@ var Start = &types.DefaultCommand{
 		Module:      "PREDICTIONS",
 		IsReply:     true,
 	},
+	Platforms:         []platformentity.Platform{platformentity.PlatformTwitch},
 	SkipToxicityCheck: true,
 	ArgsDelimiter:     " | ",
 	Args: []command_arguments.Arg{

--- a/apps/parser/internal/commands/shoutout/shoutout.go
+++ b/apps/parser/internal/commands/shoutout/shoutout.go
@@ -8,6 +8,7 @@ import (
 	"github.com/twirapp/twir/apps/parser/internal/types"
 	"github.com/twirapp/twir/apps/parser/locales"
 	"github.com/twirapp/twir/libs/bus-core/tokens"
+	platformentity "github.com/twirapp/twir/libs/entities/platform"
 	"github.com/twirapp/twir/libs/i18n"
 
 	"github.com/guregu/null"
@@ -32,6 +33,7 @@ var ShoutOut = &types.DefaultCommand{
 		Module:      "MODERATION",
 		IsReply:     true,
 	},
+	Platforms: []platformentity.Platform{platformentity.PlatformTwitch},
 	Args: []command_arguments.Arg{
 		command_arguments.String{
 			Name: userArgName,

--- a/apps/parser/internal/commands/subage/subage.go
+++ b/apps/parser/internal/commands/subage/subage.go
@@ -9,6 +9,7 @@ import (
 	"github.com/twirapp/twir/apps/parser/internal/types"
 	"github.com/twirapp/twir/apps/parser/locales"
 	"github.com/twirapp/twir/apps/parser/pkg/helpers"
+	platformentity "github.com/twirapp/twir/libs/entities/platform"
 	model "github.com/twirapp/twir/libs/gomodels"
 	"github.com/twirapp/twir/libs/i18n"
 	"github.com/twirapp/twir/libs/twitch"
@@ -23,6 +24,7 @@ var SubAge = &types.DefaultCommand{
 		Visible:     true,
 		IsReply:     true,
 	},
+	Platforms: []platformentity.Platform{platformentity.PlatformTwitch},
 	Handler: func(ctx context.Context, parseCtx *types.ParseContext) (
 		*types.CommandsHandlerResult,
 		error,

--- a/apps/parser/internal/commands/utility/firstfollowers.go
+++ b/apps/parser/internal/commands/utility/firstfollowers.go
@@ -11,6 +11,7 @@ import (
 	"github.com/lib/pq"
 	"github.com/twirapp/twir/apps/parser/internal/types"
 	"github.com/twirapp/twir/apps/parser/pkg/helpers"
+	platformentity "github.com/twirapp/twir/libs/entities/platform"
 	model "github.com/twirapp/twir/libs/gomodels"
 	"github.com/twirapp/twir/libs/twitch"
 )
@@ -31,6 +32,7 @@ var FirstFollowers = &types.DefaultCommand{
 		Aliases:     []string{},
 		Enabled:     true,
 	},
+	Platforms:         []platformentity.Platform{platformentity.PlatformTwitch},
 	SkipToxicityCheck: true,
 	Handler: func(ctx context.Context, parseCtx *types.ParseContext) (
 		*types.CommandsHandlerResult,

--- a/apps/parser/internal/commands/vips/add.go
+++ b/apps/parser/internal/commands/vips/add.go
@@ -32,6 +32,7 @@ var Add = &types.DefaultCommand{
 		Visible: true,
 		IsReply: true,
 	},
+	Platforms:         []platformentity.Platform{platformentity.PlatformTwitch},
 	SkipToxicityCheck: true,
 	Args: []command_arguments.Arg{
 		command_arguments.String{

--- a/apps/parser/internal/commands/vips/list.go
+++ b/apps/parser/internal/commands/vips/list.go
@@ -14,6 +14,7 @@ import (
 	"github.com/twirapp/twir/apps/parser/internal/types"
 	"github.com/twirapp/twir/apps/parser/locales"
 	"github.com/twirapp/twir/libs/cache/twitch"
+	platformentity "github.com/twirapp/twir/libs/entities/platform"
 	scheduledvipsentity "github.com/twirapp/twir/libs/entities/scheduled_vips"
 	model "github.com/twirapp/twir/libs/gomodels"
 	"github.com/twirapp/twir/libs/i18n"
@@ -33,6 +34,7 @@ var List = &types.DefaultCommand{
 		Visible: true,
 		IsReply: true,
 	},
+	Platforms:         []platformentity.Platform{platformentity.PlatformTwitch},
 	SkipToxicityCheck: true,
 	Handler: func(ctx context.Context, parseCtx *types.ParseContext) (
 		*types.CommandsHandlerResult,

--- a/apps/parser/internal/commands/vips/remove.go
+++ b/apps/parser/internal/commands/vips/remove.go
@@ -9,6 +9,7 @@ import (
 	command_arguments "github.com/twirapp/twir/apps/parser/internal/command-arguments"
 	"github.com/twirapp/twir/apps/parser/internal/types"
 	"github.com/twirapp/twir/apps/parser/locales"
+	platformentity "github.com/twirapp/twir/libs/entities/platform"
 	model "github.com/twirapp/twir/libs/gomodels"
 	"github.com/twirapp/twir/libs/i18n"
 	"github.com/twirapp/twir/libs/twitch"
@@ -26,6 +27,7 @@ var Remove = &types.DefaultCommand{
 		Visible: true,
 		IsReply: true,
 	},
+	Platforms:         []platformentity.Platform{platformentity.PlatformTwitch},
 	SkipToxicityCheck: true,
 	Args: []command_arguments.Arg{
 		command_arguments.String{

--- a/apps/parser/internal/commands/vips/set_expire.go
+++ b/apps/parser/internal/commands/vips/set_expire.go
@@ -32,6 +32,7 @@ var SetExpire = &types.DefaultCommand{
 		Visible: true,
 		IsReply: true,
 	},
+	Platforms:         []platformentity.Platform{platformentity.PlatformTwitch},
 	SkipToxicityCheck: true,
 	Args: []command_arguments.Arg{
 		command_arguments.String{

--- a/apps/parser/internal/types/commands.go
+++ b/apps/parser/internal/types/commands.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	command_arguments "github.com/twirapp/twir/apps/parser/internal/command-arguments"
+	platformentity "github.com/twirapp/twir/libs/entities/platform"
 	model "github.com/twirapp/twir/libs/gomodels"
 )
 
@@ -30,4 +31,6 @@ type DefaultCommand struct {
 	Args              []command_arguments.Arg
 	ArgsDelimiter     string
 	SkipToxicityCheck bool
+	// Platforms restricts this command to specific platforms; empty means all platforms.
+	Platforms []platformentity.Platform
 }

--- a/apps/parser/internal/types/variables.go
+++ b/apps/parser/internal/types/variables.go
@@ -2,6 +2,8 @@ package types
 
 import (
 	"context"
+
+	platformentity "github.com/twirapp/twir/libs/entities/platform"
 )
 
 type VariableHandlerResult struct {
@@ -32,6 +34,8 @@ type Variable struct {
 	NotCachable              bool
 	Priority                 int // Higher number = higher priority, default 0
 	Links                    []VariableLink
+	// Platforms restricts this variable to specific platforms; empty means all platforms.
+	Platforms []platformentity.Platform
 }
 
 type VariableLink struct {

--- a/apps/parser/internal/variables-bus/variables-bus.go
+++ b/apps/parser/internal/variables-bus/variables-bus.go
@@ -45,6 +45,7 @@ func New(
 				Visible:             lo.FromPtr(variable.Visible),
 				CanBeUsedInRegistry: variable.CanBeUsedInRegistry,
 				Links:               links,
+				Platforms:           variable.Platforms,
 			},
 		)
 	}

--- a/apps/parser/internal/variables/7tv/created_at.go
+++ b/apps/parser/internal/variables/7tv/created_at.go
@@ -7,12 +7,14 @@ import (
 	"github.com/twirapp/twir/apps/parser/internal/types"
 	"github.com/twirapp/twir/apps/parser/locales"
 	"github.com/twirapp/twir/apps/parser/pkg/helpers"
+	platformentity "github.com/twirapp/twir/libs/entities/platform"
 	"github.com/twirapp/twir/libs/i18n"
 )
 
 var ProfileCreatedAt = &types.Variable{
 	Name:         "7tv.profile.createdAt",
 	Description:  lo.ToPtr("Date when profile created on 7tv"),
+	Platforms:    []platformentity.Platform{platformentity.PlatformTwitch, platformentity.PlatformKick},
 	CommandsOnly: false,
 	Handler: func(
 		ctx context.Context, parseCtx *types.VariableParseContext, variableData *types.VariableData,

--- a/apps/parser/internal/variables/7tv/editor.go
+++ b/apps/parser/internal/variables/7tv/editor.go
@@ -7,12 +7,14 @@ import (
 	"github.com/samber/lo"
 	"github.com/twirapp/twir/apps/parser/internal/types"
 	"github.com/twirapp/twir/apps/parser/locales"
+	platformentity "github.com/twirapp/twir/libs/entities/platform"
 	"github.com/twirapp/twir/libs/i18n"
 )
 
 var EditorForCount = &types.Variable{
 	Name:         "7tv.editorfor.count",
 	Description:  lo.ToPtr("Count of channels where user is editor"),
+	Platforms:    []platformentity.Platform{platformentity.PlatformTwitch, platformentity.PlatformKick},
 	CommandsOnly: false,
 	Handler: func(
 		ctx context.Context, parseCtx *types.VariableParseContext, variableData *types.VariableData,

--- a/apps/parser/internal/variables/7tv/emote_set.go
+++ b/apps/parser/internal/variables/7tv/emote_set.go
@@ -8,12 +8,14 @@ import (
 	"github.com/samber/lo"
 	"github.com/twirapp/twir/apps/parser/internal/types"
 	"github.com/twirapp/twir/apps/parser/locales"
+	platformentity "github.com/twirapp/twir/libs/entities/platform"
 	"github.com/twirapp/twir/libs/i18n"
 )
 
 var EmoteSetName = &types.Variable{
 	Name:         "7tv.emoteset.name",
 	Description:  lo.ToPtr("Name of 7tv emote set"),
+	Platforms:    []platformentity.Platform{platformentity.PlatformTwitch, platformentity.PlatformKick},
 	CommandsOnly: false,
 	Handler: func(
 		ctx context.Context, parseCtx *types.VariableParseContext, variableData *types.VariableData,
@@ -39,6 +41,7 @@ var EmoteSetName = &types.Variable{
 var EmoteSetLink = &types.Variable{
 	Name:         "7tv.emoteset.link",
 	Description:  lo.ToPtr("Link to 7tv emote set"),
+	Platforms:    []platformentity.Platform{platformentity.PlatformTwitch, platformentity.PlatformKick},
 	CommandsOnly: true,
 	Handler: func(
 		ctx context.Context, parseCtx *types.VariableParseContext, variableData *types.VariableData,
@@ -64,6 +67,7 @@ var EmoteSetLink = &types.Variable{
 var EmoteSetCount = &types.Variable{
 	Name:         "7tv.emoteset.emotes.count",
 	Description:  lo.ToPtr("Count of emotes in emote set"),
+	Platforms:    []platformentity.Platform{platformentity.PlatformTwitch, platformentity.PlatformKick},
 	CommandsOnly: true,
 	Handler: func(
 		ctx context.Context, parseCtx *types.VariableParseContext, variableData *types.VariableData,
@@ -89,6 +93,7 @@ var EmoteSetCount = &types.Variable{
 var EmoteSetCapacity = &types.Variable{
 	Name:         "7tv.emoteset.capacity",
 	Description:  lo.ToPtr("Capacity of set"),
+	Platforms:    []platformentity.Platform{platformentity.PlatformTwitch, platformentity.PlatformKick},
 	CommandsOnly: true,
 	Handler: func(
 		ctx context.Context, parseCtx *types.VariableParseContext, variableData *types.VariableData,

--- a/apps/parser/internal/variables/7tv/paint.go
+++ b/apps/parser/internal/variables/7tv/paint.go
@@ -7,12 +7,14 @@ import (
 	"github.com/samber/lo"
 	"github.com/twirapp/twir/apps/parser/internal/types"
 	"github.com/twirapp/twir/apps/parser/locales"
+	platformentity "github.com/twirapp/twir/libs/entities/platform"
 	"github.com/twirapp/twir/libs/i18n"
 )
 
 var Paint = &types.Variable{
 	Name:         "7tv.profile.paint",
 	Description:  lo.ToPtr("Paint of profile"),
+	Platforms:    []platformentity.Platform{platformentity.PlatformTwitch, platformentity.PlatformKick},
 	CommandsOnly: false,
 	Handler: func(
 		ctx context.Context, parseCtx *types.VariableParseContext, variableData *types.VariableData,
@@ -38,6 +40,7 @@ var Paint = &types.Variable{
 var UnlockedPaints = &types.Variable{
 	Name:         "7tv.profile.unlockedpaints",
 	Description:  lo.ToPtr("Num of unlocked paints"),
+	Platforms:    []platformentity.Platform{platformentity.PlatformTwitch, platformentity.PlatformKick},
 	CommandsOnly: true,
 	Handler: func(
 		ctx context.Context, parseCtx *types.VariableParseContext, variableData *types.VariableData,

--- a/apps/parser/internal/variables/7tv/profile_link.go
+++ b/apps/parser/internal/variables/7tv/profile_link.go
@@ -6,12 +6,14 @@ import (
 	"github.com/samber/lo"
 	"github.com/twirapp/twir/apps/parser/internal/types"
 	"github.com/twirapp/twir/apps/parser/locales"
+	platformentity "github.com/twirapp/twir/libs/entities/platform"
 	"github.com/twirapp/twir/libs/i18n"
 )
 
 var ProfileLink = &types.Variable{
 	Name:         "7tv.profile.link",
 	Description:  lo.ToPtr("Link to 7tv profile"),
+	Platforms:    []platformentity.Platform{platformentity.PlatformTwitch, platformentity.PlatformKick},
 	CommandsOnly: false,
 	Handler: func(
 		ctx context.Context, parseCtx *types.VariableParseContext, variableData *types.VariableData,

--- a/apps/parser/internal/variables/7tv/roles.go
+++ b/apps/parser/internal/variables/7tv/roles.go
@@ -7,12 +7,14 @@ import (
 	"github.com/samber/lo"
 	"github.com/twirapp/twir/apps/parser/internal/types"
 	"github.com/twirapp/twir/apps/parser/locales"
+	platformentity "github.com/twirapp/twir/libs/entities/platform"
 	"github.com/twirapp/twir/libs/i18n"
 )
 
 var Roles = &types.Variable{
 	Name:         "7tv.roles",
 	Description:  lo.ToPtr("Roles of user on 7tv"),
+	Platforms:    []platformentity.Platform{platformentity.PlatformTwitch, platformentity.PlatformKick},
 	CommandsOnly: false,
 	Handler: func(
 		ctx context.Context, parseCtx *types.VariableParseContext, variableData *types.VariableData,

--- a/apps/parser/internal/variables/channel/channel_name.go
+++ b/apps/parser/internal/variables/channel/channel_name.go
@@ -11,6 +11,7 @@ import (
 var TwitchName = &types.Variable{
 	Name:         "channel.twitch.name",
 	Description:  new("Twitch Name of channel. Empty in case of twitch not connected"),
+	Platforms:    []platform.Platform{platform.PlatformTwitch},
 	CommandsOnly: true,
 	Handler: func(
 		ctx context.Context, parseCtx *types.VariableParseContext, variableData *types.VariableData,
@@ -46,6 +47,7 @@ var TwitchName = &types.Variable{
 var KickName = &types.Variable{
 	Name:         "channel.kick.name",
 	Description:  new("Kick Name of channel. Empty in case of Kick not connected"),
+	Platforms:    []platform.Platform{platform.PlatformKick},
 	CommandsOnly: true,
 	Handler: func(
 		ctx context.Context, parseCtx *types.VariableParseContext, variableData *types.VariableData,

--- a/apps/parser/internal/variables/channel/id.go
+++ b/apps/parser/internal/variables/channel/id.go
@@ -22,6 +22,7 @@ var ID = &types.Variable{
 var TwitchID = &types.Variable{
 	Name:         "channel.twitch.id",
 	Description:  new("Twitch ID of channel. Empty in case of twitch not connected"),
+	Platforms:    []platform.Platform{platform.PlatformTwitch},
 	CommandsOnly: true,
 	Handler: func(
 		ctx context.Context, parseCtx *types.VariableParseContext, variableData *types.VariableData,
@@ -48,6 +49,7 @@ var TwitchID = &types.Variable{
 var KickID = &types.Variable{
 	Name:         "channel.kick.id",
 	Description:  new("Kick ID of channel. Empty in case of twitch not connected"),
+	Platforms:    []platform.Platform{platform.PlatformKick},
 	CommandsOnly: true,
 	Handler: func(
 		ctx context.Context, parseCtx *types.VariableParseContext, variableData *types.VariableData,

--- a/apps/parser/internal/variables/emotes/7tv.go
+++ b/apps/parser/internal/variables/emotes/7tv.go
@@ -26,6 +26,7 @@ type sevenUserTvResponse struct {
 var SevenTv = &types.Variable{
 	Name:                "emotes.7tv",
 	Description:         lo.ToPtr("Emotes of channel from https://7tv.app"),
+	Platforms:           []platformentity.Platform{platformentity.PlatformTwitch, platformentity.PlatformKick},
 	CanBeUsedInRegistry: true,
 	Handler: shared.HandlerByPlatform(map[platformentity.Platform]types.VariableHandler{
 		shared.PlatformTwitch: sevenTVHandler(shared.PlatformTwitch),

--- a/apps/parser/internal/variables/emotes/bttv.go
+++ b/apps/parser/internal/variables/emotes/bttv.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/samber/lo"
 	"github.com/twirapp/twir/apps/parser/internal/types"
+	platformentity "github.com/twirapp/twir/libs/entities/platform"
 )
 
 type betterTTVEmote struct {
@@ -23,6 +24,7 @@ type betterTTVResponse struct {
 var BetterTTV = &types.Variable{
 	Name:        "emotes.bttv",
 	Description: lo.ToPtr("Emotes of channel from https://betterttv.com/"),
+	Platforms:   []platformentity.Platform{platformentity.PlatformTwitch},
 	Handler: func(
 		ctx context.Context, parseCtx *types.VariableParseContext, variableData *types.VariableData,
 	) (*types.VariableHandlerResult, error) {

--- a/apps/parser/internal/variables/emotes/ffz.go
+++ b/apps/parser/internal/variables/emotes/ffz.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/samber/lo"
 	"github.com/twirapp/twir/apps/parser/internal/types"
+	platformentity "github.com/twirapp/twir/libs/entities/platform"
 )
 
 type frankerFaceZEmote struct {
@@ -26,6 +27,7 @@ type frankerFaceZResponse struct {
 var FrankerFaceZ = &types.Variable{
 	Name:        "emotes.ffz",
 	Description: lo.ToPtr("Emotes of channel from https://frankerfacez.com"),
+	Platforms:   []platformentity.Platform{platformentity.PlatformTwitch},
 	Handler: func(
 		ctx context.Context, parseCtx *types.VariableParseContext, variableData *types.VariableData,
 	) (*types.VariableHandlerResult, error) {

--- a/apps/parser/internal/variables/followers/followers.go
+++ b/apps/parser/internal/variables/followers/followers.go
@@ -8,6 +8,7 @@ import (
 	"github.com/samber/lo"
 	"github.com/twirapp/twir/apps/parser/internal/types"
 	"github.com/twirapp/twir/apps/parser/locales"
+	platformentity "github.com/twirapp/twir/libs/entities/platform"
 	model "github.com/twirapp/twir/libs/gomodels"
 	"github.com/twirapp/twir/libs/i18n"
 	"github.com/twirapp/twir/libs/twitch"
@@ -48,6 +49,7 @@ var LatestFollowerUsername = &types.Variable{
 var Count = &types.Variable{
 	Name:                "followers.count",
 	Description:         lo.ToPtr("Followers count"),
+	Platforms:           []platformentity.Platform{platformentity.PlatformTwitch},
 	CanBeUsedInRegistry: true,
 	Handler: func(
 		ctx context.Context,

--- a/apps/parser/internal/variables/stream/description.go
+++ b/apps/parser/internal/variables/stream/description.go
@@ -14,6 +14,7 @@ import (
 var Description = &types.Variable{
 	Name:                "stream.description",
 	Description:         lo.ToPtr("Stream description"),
+	Platforms:           []platformentity.Platform{platformentity.PlatformKick},
 	CanBeUsedInRegistry: true,
 	Handler: func(
 		ctx context.Context, parseCtx *types.VariableParseContext, variableData *types.VariableData,

--- a/apps/parser/internal/variables/stream/slug.go
+++ b/apps/parser/internal/variables/stream/slug.go
@@ -14,6 +14,7 @@ import (
 var Slug = &types.Variable{
 	Name:                "stream.slug",
 	Description:         lo.ToPtr("Stream slug"),
+	Platforms:           []platformentity.Platform{platformentity.PlatformKick},
 	CanBeUsedInRegistry: true,
 	Handler: func(
 		ctx context.Context, parseCtx *types.VariableParseContext, variableData *types.VariableData,

--- a/apps/parser/internal/variables/subscribers/subscribers.go
+++ b/apps/parser/internal/variables/subscribers/subscribers.go
@@ -18,6 +18,7 @@ import (
 var LatestSubscriberUsername = &types.Variable{
 	Name:                "subscribers.latest.userName",
 	Description:         lo.ToPtr("Latest subscriber username"),
+	Platforms:           []platformentity.Platform{platformentity.PlatformTwitch},
 	CanBeUsedInRegistry: true,
 	Handler: func(
 		ctx context.Context,
@@ -70,6 +71,7 @@ var LatestSubscriberUsername = &types.Variable{
 var Count = &types.Variable{
 	Name:                "subscribers.count",
 	Description:         lo.ToPtr("Subscribers count"),
+	Platforms:           []platformentity.Platform{platformentity.PlatformTwitch, platformentity.PlatformKick},
 	CanBeUsedInRegistry: true,
 	Handler: shared.HandlerByPlatform(map[platformentity.Platform]types.VariableHandler{
 		shared.PlatformTwitch: func(

--- a/apps/parser/internal/variables/top/channel_points.go
+++ b/apps/parser/internal/variables/top/channel_points.go
@@ -8,12 +8,14 @@ import (
 
 	"github.com/samber/lo"
 	"github.com/twirapp/twir/apps/parser/internal/types"
+	platformentity "github.com/twirapp/twir/libs/entities/platform"
 )
 
 var ChannelPoints = &types.Variable{
 	Name:                "top.usedChannelPoints",
 	Description:         lo.ToPtr("Top users by spent channel points"),
 	Example:             lo.ToPtr("top.usedChannelPoints|10"),
+	Platforms:           []platformentity.Platform{platformentity.PlatformTwitch},
 	CanBeUsedInRegistry: true,
 	Handler: func(
 		ctx context.Context, parseCtx *types.VariableParseContext, variableData *types.VariableData,

--- a/apps/parser/internal/variables/top/kicks.go
+++ b/apps/parser/internal/variables/top/kicks.go
@@ -5,8 +5,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/scorfly/gokick"
 	"github.com/samber/lo"
+	"github.com/scorfly/gokick"
 	"github.com/twirapp/twir/apps/parser/internal/types"
 	sharedvars "github.com/twirapp/twir/apps/parser/internal/variables/shared"
 	platformentity "github.com/twirapp/twir/libs/entities/platform"
@@ -66,6 +66,7 @@ func kickLeaderboardVariable(name string, selector func(kickLeaderboardData) []k
 	return &types.Variable{
 		Name:                name,
 		Description:         lo.ToPtr("Kick gifted kicks leaderboard"),
+		Platforms:           []platformentity.Platform{platformentity.PlatformKick},
 		CanBeUsedInRegistry: true,
 		Handler: func(
 			ctx context.Context, parseCtx *types.VariableParseContext, variableData *types.VariableData,

--- a/apps/parser/internal/variables/user/age.go
+++ b/apps/parser/internal/variables/user/age.go
@@ -16,6 +16,7 @@ import (
 var Age = &types.Variable{
 	Name:         "user.age",
 	Description:  lo.ToPtr("User account age"),
+	Platforms:    []platformentity.Platform{platformentity.PlatformTwitch, platformentity.PlatformKick},
 	CommandsOnly: true,
 	Handler: shared.HandlerByPlatform(map[platformentity.Platform]types.VariableHandler{
 		shared.PlatformTwitch: func(

--- a/apps/parser/internal/variables/user/follow_age.go
+++ b/apps/parser/internal/variables/user/follow_age.go
@@ -16,6 +16,7 @@ import (
 var FollowAge = &types.Variable{
 	Name:         "user.followage",
 	Description:  new(`User followage duration in "1y 3mo 22d" format`),
+	Platforms:    []platformentity.Platform{platformentity.PlatformTwitch, platformentity.PlatformKick},
 	CommandsOnly: true,
 	Handler: shared.HandlerByPlatform(map[platformentity.Platform]types.VariableHandler{
 		shared.PlatformTwitch: func(

--- a/apps/parser/internal/variables/user/follow_since.go
+++ b/apps/parser/internal/variables/user/follow_since.go
@@ -8,12 +8,14 @@ import (
 	"github.com/samber/lo"
 	"github.com/twirapp/twir/apps/parser/internal/types"
 	"github.com/twirapp/twir/apps/parser/locales"
+	platformentity "github.com/twirapp/twir/libs/entities/platform"
 	"github.com/twirapp/twir/libs/i18n"
 )
 
 var FollowSince = &types.Variable{
 	Name:         "user.followsince",
 	Description:  lo.ToPtr(`User follow since in "16 January 2023 (22 days)" format.`),
+	Platforms:    []platformentity.Platform{platformentity.PlatformTwitch},
 	CommandsOnly: true,
 	Handler: func(
 		ctx context.Context, parseCtx *types.VariableParseContext, variableData *types.VariableData,

--- a/apps/parser/internal/variables/user/used_channels_points.go
+++ b/apps/parser/internal/variables/user/used_channels_points.go
@@ -6,11 +6,13 @@ import (
 
 	"github.com/samber/lo"
 	"github.com/twirapp/twir/apps/parser/internal/types"
+	platformentity "github.com/twirapp/twir/libs/entities/platform"
 )
 
 var UsedChannelPoints = &types.Variable{
 	Name:         "user.usedChannelPoints",
 	Description:  lo.ToPtr("How many channel points user spent on channel"),
+	Platforms:    []platformentity.Platform{platformentity.PlatformTwitch},
 	CommandsOnly: true,
 	Handler: func(
 		ctx context.Context, parseCtx *types.VariableParseContext, variableData *types.VariableData,

--- a/libs/bus-core/parser/commands.go
+++ b/libs/bus-core/parser/commands.go
@@ -45,4 +45,5 @@ type DefaultCommand struct {
 	IsReply            bool
 	KeepResponsesOrder bool
 	Aliases            []string
+	Platforms          []platformentity.Platform
 }

--- a/libs/bus-core/parser/variables.go
+++ b/libs/bus-core/parser/variables.go
@@ -1,5 +1,7 @@
 package parser
 
+import platformentity "github.com/twirapp/twir/libs/entities/platform"
+
 const GetBuiltInVariablesSubject = "parser.get_build_in_variables"
 
 type BuiltInVariable struct {
@@ -9,6 +11,7 @@ type BuiltInVariable struct {
 	Visible             bool
 	CanBeUsedInRegistry bool
 	Links               []BuiltInVariableLink
+	Platforms           []platformentity.Platform
 }
 
 type BuiltInVariableLink struct {

--- a/web/layers/dashboard/api/commands/default-commands.ts
+++ b/web/layers/dashboard/api/commands/default-commands.ts
@@ -1,0 +1,37 @@
+import { useQuery } from '@urql/vue'
+import { createGlobalState } from '@vueuse/core'
+import { computed } from 'vue'
+
+import { graphql } from '~/gql/gql.js'
+
+export const useDefaultCommandsApi = createGlobalState(() => {
+	const query = useQuery({
+		variables: {},
+		query: graphql(`
+			query GetDefaultCommandsInfo {
+				commandsDefault {
+					name
+					description
+					module
+					aliases
+					platforms
+				}
+			}
+		`),
+	})
+
+	const defaultCommands = computed(() => query.data.value?.commandsDefault ?? [])
+
+	const defaultCommandPlatforms = computed(() => {
+		const platformsByName = new Map<string, string[]>()
+		for (const command of defaultCommands.value) {
+			platformsByName.set(command.name, command.platforms)
+		}
+		return platformsByName
+	})
+
+	return {
+		defaultCommands,
+		defaultCommandPlatforms,
+	}
+})

--- a/web/layers/dashboard/api/commands/default-commands.ts
+++ b/web/layers/dashboard/api/commands/default-commands.ts
@@ -2,6 +2,8 @@ import { useQuery } from '@urql/vue'
 import { createGlobalState } from '@vueuse/core'
 import { computed } from 'vue'
 
+import type { Platform } from '~/gql/graphql.js'
+
 import { graphql } from '~/gql/gql.js'
 
 export const useDefaultCommandsApi = createGlobalState(() => {
@@ -23,7 +25,7 @@ export const useDefaultCommandsApi = createGlobalState(() => {
 	const defaultCommands = computed(() => query.data.value?.commandsDefault ?? [])
 
 	const defaultCommandPlatforms = computed(() => {
-		const platformsByName = new Map<string, string[]>()
+		const platformsByName = new Map<string, Platform[]>()
 		for (const command of defaultCommands.value) {
 			platformsByName.set(command.name, command.platforms)
 		}

--- a/web/layers/dashboard/api/variables.ts
+++ b/web/layers/dashboard/api/variables.ts
@@ -36,6 +36,7 @@ export const useVariablesApi = createGlobalState(() => {
 					description
 					visible
 					canBeUsedInRegistry
+					platforms
 					links {
 						href
 						name
@@ -55,6 +56,7 @@ export const useVariablesApi = createGlobalState(() => {
 				example: `customvar|${variable.name}`,
 				isBuiltIn: false,
 				canBeUsedInRegistry: variable.type !== VariableType.Script,
+				platforms: [],
 				type: variable.type,
 				response: variable.response,
 				evalValue: variable.evalValue,
@@ -74,6 +76,7 @@ export const useVariablesApi = createGlobalState(() => {
 				example: variable.example || `${variable.name}`,
 				isBuiltIn: true,
 				canBeUsedInRegistry: variable.canBeUsedInRegistry,
+				platforms: variable.platforms,
 				links: variable.links,
 			})) ?? [];
 

--- a/web/layers/dashboard/components/platform-icons.spec.ts
+++ b/web/layers/dashboard/components/platform-icons.spec.ts
@@ -1,9 +1,11 @@
 import { mount } from '@vue/test-utils'
 import { describe, expect, it } from 'vitest'
 
+import { Platform } from '~/gql/graphql.js'
+
 import PlatformIcons from './platform-icons.vue'
 
-function mountIcons(platforms: string[]) {
+function mountIcons(platforms: Platform[]) {
 	return mount(PlatformIcons, {
 		props: { platforms },
 		global: {
@@ -27,9 +29,9 @@ describe('PlatformIcons', () => {
 		expect(wrapper.findAll('i')).toHaveLength(0)
 	})
 
-	it('renders one brand icon per known platform', () => {
+	it('renders one brand icon per platform', () => {
 		// Given an entry restricted to Twitch and Kick
-		const wrapper = mountIcons(['twitch', 'kick'])
+		const wrapper = mountIcons([Platform.Twitch, Platform.Kick])
 
 		// Then two icons render with the brand glyphs and tooltip labels
 		const icons = wrapper.findAll('i')
@@ -40,13 +42,16 @@ describe('PlatformIcons', () => {
 		expect(icons[1]!.attributes('title')).toBe('Kick')
 	})
 
-	it('silently ignores unknown platform strings', () => {
-		// Given a mix of a known and an unknown platform
-		const wrapper = mountIcons(['twitch', 'myspace'])
+	it('supports every platform of the enum', () => {
+		// Given an entry restricted to all four platforms
+		const wrapper = mountIcons([
+			Platform.Twitch,
+			Platform.Kick,
+			Platform.VkVideoLive,
+			Platform.Youtube,
+		])
 
-		// Then only the known platform renders an icon
-		const icons = wrapper.findAll('i')
-		expect(icons).toHaveLength(1)
-		expect(icons[0]!.attributes('data-icon')).toBe('simple-icons:twitch')
+		// Then all four brand icons render
+		expect(wrapper.findAll('i')).toHaveLength(4)
 	})
 })

--- a/web/layers/dashboard/components/platform-icons.spec.ts
+++ b/web/layers/dashboard/components/platform-icons.spec.ts
@@ -1,0 +1,52 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+
+import PlatformIcons from './platform-icons.vue'
+
+function mountIcons(platforms: string[]) {
+	return mount(PlatformIcons, {
+		props: { platforms },
+		global: {
+			stubs: {
+				NuxtIcon: {
+					props: ['name'],
+					template: '<i :data-icon="name" />',
+				},
+			},
+		},
+	})
+}
+
+describe('PlatformIcons', () => {
+	it('renders nothing when the platforms list is empty', () => {
+		// Given an entry available on every platform
+		const wrapper = mountIcons([])
+
+		// Then no container and no icons are rendered
+		expect(wrapper.find('div').exists()).toBe(false)
+		expect(wrapper.findAll('i')).toHaveLength(0)
+	})
+
+	it('renders one brand icon per known platform', () => {
+		// Given an entry restricted to Twitch and Kick
+		const wrapper = mountIcons(['twitch', 'kick'])
+
+		// Then two icons render with the brand glyphs and tooltip labels
+		const icons = wrapper.findAll('i')
+		expect(icons).toHaveLength(2)
+		expect(icons[0]!.attributes('data-icon')).toBe('simple-icons:twitch')
+		expect(icons[0]!.attributes('title')).toBe('Twitch')
+		expect(icons[1]!.attributes('data-icon')).toBe('simple-icons:kick')
+		expect(icons[1]!.attributes('title')).toBe('Kick')
+	})
+
+	it('silently ignores unknown platform strings', () => {
+		// Given a mix of a known and an unknown platform
+		const wrapper = mountIcons(['twitch', 'myspace'])
+
+		// Then only the known platform renders an icon
+		const icons = wrapper.findAll('i')
+		expect(icons).toHaveLength(1)
+		expect(icons[0]!.attributes('data-icon')).toBe('simple-icons:twitch')
+	})
+})

--- a/web/layers/dashboard/components/platform-icons.vue
+++ b/web/layers/dashboard/components/platform-icons.vue
@@ -1,16 +1,18 @@
 <script setup lang="ts">
 import type { HTMLAttributes } from 'vue'
 
+import { Platform } from '~/gql/graphql.js'
+
 const props = defineProps<{
-	platforms: string[]
+	platforms: Platform[]
 	class?: HTMLAttributes['class']
 }>()
 
 const platformOptions = [
-	{ id: 'twitch', label: 'Twitch', icon: 'simple-icons:twitch', colorClass: 'text-[#9146FF]' },
-	{ id: 'kick', label: 'Kick', icon: 'simple-icons:kick', colorClass: 'text-[#53FC18]' },
-	{ id: 'vk_video_live', label: 'VK Video Live', icon: 'simple-icons:vk', colorClass: 'text-[#0077FF]' },
-	{ id: 'youtube', label: 'YouTube', icon: 'simple-icons:youtube', colorClass: 'text-[#FF0000]' },
+	{ id: Platform.Twitch, label: 'Twitch', icon: 'simple-icons:twitch', colorClass: 'text-[#9146FF]' },
+	{ id: Platform.Kick, label: 'Kick', icon: 'simple-icons:kick', colorClass: 'text-[#53FC18]' },
+	{ id: Platform.VkVideoLive, label: 'VK Video Live', icon: 'simple-icons:vk', colorClass: 'text-[#0077FF]' },
+	{ id: Platform.Youtube, label: 'YouTube', icon: 'simple-icons:youtube', colorClass: 'text-[#FF0000]' },
 ] as const
 
 const visiblePlatforms = computed(() =>

--- a/web/layers/dashboard/components/platform-icons.vue
+++ b/web/layers/dashboard/components/platform-icons.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from 'vue'
+
+const props = defineProps<{
+	platforms: string[]
+	class?: HTMLAttributes['class']
+}>()
+
+const platformOptions = [
+	{ id: 'twitch', label: 'Twitch', icon: 'simple-icons:twitch', colorClass: 'text-[#9146FF]' },
+	{ id: 'kick', label: 'Kick', icon: 'simple-icons:kick', colorClass: 'text-[#53FC18]' },
+	{ id: 'vk_video_live', label: 'VK Video Live', icon: 'simple-icons:vk', colorClass: 'text-[#0077FF]' },
+	{ id: 'youtube', label: 'YouTube', icon: 'simple-icons:youtube', colorClass: 'text-[#FF0000]' },
+] as const
+
+const visiblePlatforms = computed(() =>
+	platformOptions.filter((option) => props.platforms.includes(option.id))
+)
+</script>
+
+<template>
+	<div
+		v-if="visiblePlatforms.length"
+		class="flex items-center gap-1"
+		:class="props.class"
+	>
+		<Icon
+			v-for="platform in visiblePlatforms"
+			:key="platform.id"
+			:name="platform.icon"
+			:title="platform.label"
+			class="size-3.5"
+			:class="platform.colorClass"
+		/>
+	</div>
+</template>

--- a/web/layers/dashboard/components/variables-list.vue
+++ b/web/layers/dashboard/components/variables-list.vue
@@ -14,6 +14,8 @@ import {
 } from '@/components/ui/command'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 
+import PlatformIcons from './platform-icons.vue'
+
 defineProps<{
 	popoverAlign?: 'start' | 'center' | 'end'
 	popoverSide?: 'top' | 'right' | 'bottom' | 'left'
@@ -32,6 +34,7 @@ const selectVariables = computed(() => {
 		value: `$(${variable.example})`,
 		description: variable.description,
 		links: variable.links,
+		platforms: variable.platforms,
 	}))
 })
 
@@ -69,7 +72,10 @@ function handleSelect(value: string) {
 							@select="handleSelect(option.value)"
 						>
 							<div class="flex flex-col flex-wrap gap-0.5">
-								<span>{{ option.label }}</span>
+								<div class="flex items-center gap-1.5">
+									<span>{{ option.label }}</span>
+									<PlatformIcons :platforms="option.platforms" />
+								</div>
 								<span
 									v-if="option.description"
 									class="text-xs"

--- a/web/layers/dashboard/features/commands/ui/list.vue
+++ b/web/layers/dashboard/features/commands/ui/list.vue
@@ -10,9 +10,13 @@ import type { Command } from '~/gql/graphql.js'
 
 import Table from '~~/layers/dashboard/components/table.vue'
 import TextWithVariables from '~~/layers/dashboard/components/text-with-variables.vue'
+import PlatformIcons from '~~/layers/dashboard/components/platform-icons.vue'
+import { useDefaultCommandsApi } from '~~/layers/dashboard/api/commands/default-commands.js'
 
 import ColumnActions from './list-actions.vue'
 import { type Group, createGroups, isCommand } from './list-groups.js'
+
+const { defaultCommandPlatforms } = useDefaultCommandsApi()
 
 const props = withDefaults(
 	defineProps<{
@@ -37,9 +41,18 @@ const columns: ColumnDef<Command | Group>[] = [
 				: null
 
 			if (isCommand(row.original)) {
+				const platformIcons = row.original.default
+					? h(PlatformIcons, {
+							platforms:
+								defaultCommandPlatforms.value.get(row.original.defaultName ?? row.original.name) ??
+								[],
+						})
+					: null
+
 				return h('div', { class: 'flex gap-2 items-center' }, [
 					chevron,
 					`!${row.getValue('name')}` as string,
+					platformIcons,
 				])
 			}
 


### PR DESCRIPTION
## Summary

Implements #1022 — built-in variables and default commands now declare their platform availability, and the dashboard shows platform icons.

**Backend (Go)**
- `types.Variable` and `types.DefaultCommand` gained `Platforms []platformentity.Platform` (empty = all platforms) in the parser
- Platform-restricted variables annotated (e.g. Twitch-only: followers/subscribers/7tv/channel points/follow age; Kick-only: kicks leaderboards, stream slug/description; Twitch+Kick where applicable)
- Platform-restricted default commands annotated (shoutout, clip, predictions, vips, marker, 7tv, duel, etc. → Twitch)
- Metadata plumbed through NATS bus (`BuiltInVariable.platforms`, `DefaultCommand.platforms`)
- GraphQL: `BuiltInVariable.platforms: [String!]!` + new `commandsDefault: [DefaultCommandInfo!]!` query (gqlgen regenerated)
- Metadata only — **no runtime behavior changes**, no DB migrations

**Frontend (dashboard)**
- New shared `platform-icons.vue` component (simple-icons brand logos with tooltips; renders nothing for unrestricted entries)
- Variables picker shows icons next to restricted built-in variables
- Commands list shows availability icons next to default commands (via new `useDefaultCommandsApi`)
- Added `platform-icons.spec.ts`

## Verification
- `go build ./...` ✅
- `go test ./apps/parser/... ./libs/bus-core/...`, `./apps/api-gql/...` (257 tests) ✅
- `bun run graphql-codegen` + dashboard vitest: 45/45 ✅
- `bun lint`: no new issues (19 pre-existing errors in untouched files)

Closes #1022