### PR TITLE
fix(bots): improve translation language detection

### DIFF
--- a/apps/bots/internal/services/chat_translations/chat_translations.go
+++ b/apps/bots/internal/services/chat_translations/chat_translations.go
@@ -201,8 +201,9 @@ func (c *Service) Handle(ctx context.Context, input ChatMessageInput) error {
 	for emoteName := range input.UsedEmotesWithThirdParty {
 		textForTranslate = strings.ReplaceAll(textForTranslate, emoteName, "")
 	}
+	textForTranslate = prepareTextForTranslation(textForTranslate)
 
-	if utf8.RuneCountInString(textForTranslate) < 5 {
+	if utf8.RuneCountInString(textForTranslate) < 5 || !hasTranslatableText(textForTranslate) {
 		return nil
 	}
 

--- a/apps/bots/internal/services/chat_translations/detect_language.go
+++ b/apps/bots/internal/services/chat_translations/detect_language.go
@@ -30,7 +30,7 @@ func (c *Service) detectLanguage(ctx context.Context, text string) (*detectedLan
 
 	requestBody := detectedLangRequest{
 		Text:   text,
-		Method: "mediapipe",
+		Method: "lingua",
 	}
 
 	body := new(bytes.Buffer)

--- a/apps/bots/internal/services/chat_translations/translate.go
+++ b/apps/bots/internal/services/chat_translations/translate.go
@@ -9,14 +9,34 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"regexp"
 	"strings"
 	"time"
+	"unicode"
 
 	googletranslate "cloud.google.com/go/translate"
 	"github.com/lkretschmer/deepl-go"
 	kvoptions "github.com/twirapp/kv/options"
 	"golang.org/x/text/language"
 )
+
+var translationURLPattern = regexp.MustCompile(`(?i)(?:https?://|www\.)\S+`)
+
+func prepareTextForTranslation(text string) string {
+	text = translationURLPattern.ReplaceAllString(text, " ")
+	return strings.Join(strings.Fields(text), " ")
+}
+
+func hasTranslatableText(text string) bool {
+	letters := 0
+	for _, r := range text {
+		if unicode.IsLetter(r) {
+			letters++
+		}
+	}
+
+	return letters >= 3
+}
 
 type translateRequest struct {
 	Text          string   `json:"text"`

--- a/apps/bots/internal/services/chat_translations/translate_test.go
+++ b/apps/bots/internal/services/chat_translations/translate_test.go
@@ -1,0 +1,69 @@
+package chat_translations
+
+import "testing"
+
+func TestPrepareTextForTranslation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		text string
+		want string
+	}{
+		{
+			name: "url only",
+			text: "https://www.youtube.com/watch?v=pM9rYSN7WWY&list=PLrm7ivpQ4YpWl-OO_JIjU1zQjeWny7wqP&index=19",
+			want: "",
+		},
+		{
+			name: "text followed by url",
+			text: "check this https://example.com/watch?v=123&list=456",
+			want: "check this",
+		},
+		{
+			name: "www url between text",
+			text: "before www.example.com/path after",
+			want: "before after",
+		},
+		{
+			name: "normalizes whitespace",
+			text: "  hello\n\tworld  ",
+			want: "hello world",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := prepareTextForTranslation(tt.text); got != tt.want {
+				t.Fatalf("prepareTextForTranslation() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHasTranslatableText(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		text string
+		want bool
+	}{
+		{name: "natural text", text: "тетс триггера перевода", want: true},
+		{name: "numbers and punctuation", text: "12345 !!!", want: false},
+		{name: "too few letters", text: "ok 12345", want: false},
+		{name: "non latin letters", text: "你好世界", want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := hasTranslatableText(tt.text); got != tt.want {
+				t.Fatalf("hasTranslatableText() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- use Lingua detection to avoid misclassifying short Cyrillic messages
- strip URLs before language detection and translation
- ignore messages without enough natural-language content
- cover URL cleanup and translatable-text checks with tests

## Testing

- `go test ./internal/services/... -count=1`