### PR TITLE
fix(events): update variables through pgx

### DIFF
--- a/apps/events/internal/activities/events/variables.go
+++ b/apps/events/internal/activities/events/variables.go
@@ -10,6 +10,7 @@ import (
 	"github.com/samber/lo"
 	"github.com/twirapp/twir/apps/events/internal/shared"
 	"github.com/twirapp/twir/libs/repositories/events/model"
+	variablesrepository "github.com/twirapp/twir/libs/repositories/variables"
 	"go.temporal.io/sdk/activity"
 
 	variablesmodel "github.com/twirapp/twir/libs/repositories/variables/model"
@@ -59,8 +60,12 @@ func (c *Activity) ChangeVariableValue(
 		variable.Response = hydratedInput
 	}
 
-	if err = c.db.WithContext(ctx).Save(variable).Error; err != nil {
-		return err
+	if _, err = c.variablesRepository.Update(
+		ctx,
+		variable.ID,
+		variablesrepository.UpdateInput{Response: &variable.Response},
+	); err != nil {
+		return fmt.Errorf("cannot update variable: %w", err)
 	}
 
 	return nil
@@ -120,8 +125,12 @@ func (c *Activity) IncrementORDecrementVariable(
 			Else(currentVariableNumber-newVariableNumber),
 	)
 
-	if err = c.db.WithContext(ctx).Save(variable).Error; err != nil {
-		return err
+	if _, err = c.variablesRepository.Update(
+		ctx,
+		variable.ID,
+		variablesrepository.UpdateInput{Response: &variable.Response},
+	); err != nil {
+		return fmt.Errorf("cannot update variable: %w", err)
 	}
 
 	return nil

--- a/libs/repositories/variables/pgx/pgx.go
+++ b/libs/repositories/variables/pgx/pgx.go
@@ -167,9 +167,12 @@ func (c *Pgx) Update(
 		return model.Nil, err
 	}
 
-	_, err = c.pool.Query(ctx, query, args...)
+	result, err := c.pool.Exec(ctx, query, args...)
 	if err != nil {
 		return model.Nil, err
+	}
+	if result.RowsAffected() != 1 {
+		return model.Nil, variables.ErrNotFound
 	}
 
 	return c.GetByID(ctx, id)


### PR DESCRIPTION
## Summary

- route event variable writes through the pgx repository
- update only the response column instead of saving the full model with GORM
- use Exec and validate affected rows in the variables repository

## Why

GORM inferred the nonexistent custom_variables table from the repository model. The actual table is channels_customvars, which is already managed by the pgx repository.

## Tests

- go test ./... in apps/events: 20 tests in 10 packages
- go test ./... in libs/repositories: 43 tests in 234 packages