### PR TITLE
fix(parser): correct botuptime status

### DIFF
--- a/apps/parser/internal/commands/stats/botuptime_format.go
+++ b/apps/parser/internal/commands/stats/botuptime_format.go
@@ -17,7 +17,7 @@ import (
 const (
 	staleThreshold      = time.Minute
 	restartThreshold    = 5 * time.Minute
-	platformPingTimeout = 5 * time.Second
+	platformPingTimeout = time.Second
 	maxChatMessageRunes = 450
 )
 
@@ -55,13 +55,21 @@ func summarizeServices(
 	down := []string{}
 	restarted := []string{}
 	for _, service := range serviceNames {
-		instances := byService[service]
+		instances := visibleInstances(byService[service], now)
+		if len(instances) == 0 {
+			continue
+		}
 		labels := instanceLabels(instances)
 
 		alive := []time.Duration{}
 		for _, status := range instances {
 			if status.IsStale(now, staleThreshold) {
-				down = append(down, service+labels[status.Instance])
+				// Hostnames are ephemeral in Swarm and remain in Redis after a
+				// rolling update. Only stable replica slots can represent an
+				// instance that is actually expected to be alive.
+				if strings.HasPrefix(status.Instance, "slot-") {
+					down = append(down, service+labels[status.Instance])
+				}
 				continue
 			}
 
@@ -79,6 +87,17 @@ func summarizeServices(
 	}
 
 	return services, down, restarted
+}
+
+func visibleInstances(instances []uptime.InstanceStatus, now time.Time) []uptime.InstanceStatus {
+	visible := make([]uptime.InstanceStatus, 0, len(instances))
+	for _, instance := range instances {
+		if !instance.IsStale(now, staleThreshold) || strings.HasPrefix(instance.Instance, "slot-") {
+			visible = append(visible, instance)
+		}
+	}
+
+	return visible
 }
 
 func formatServiceUptime(service string, alive []time.Duration, unavailable string) string {

--- a/apps/parser/internal/commands/stats/botuptime_test.go
+++ b/apps/parser/internal/commands/stats/botuptime_test.go
@@ -72,3 +72,57 @@ func TestInstanceLabels_usesOrdinalsForMultipleReplicas(t *testing.T) {
 		t.Errorf("instanceLabels()[b2c3d4e5f6a7] = %q, want %q", got["b2c3d4e5f6a7"], want)
 	}
 }
+
+func TestSummarizeServices_ignoresStaleEphemeralInstances(t *testing.T) {
+	// Given
+	now := time.Date(2026, 8, 2, 12, 0, 0, 0, time.UTC)
+	statuses := []uptime.InstanceStatus{
+		{
+			Service:   "parser",
+			Instance:  "current-host",
+			StartedAt: now.Add(-time.Hour),
+			UpdatedAt: now.Add(-time.Second),
+		},
+		{
+			Service:   "parser",
+			Instance:  "old-host",
+			StartedAt: now.Add(-2 * time.Hour),
+			UpdatedAt: now.Add(-2 * time.Minute),
+		},
+	}
+
+	// When
+	services, down, _ := summarizeServices(statuses, now, "unavailable")
+
+	// Then
+	if len(services) != 1 || services[0] != "parser×1 1h" {
+		t.Fatalf("services = %v, want [parser×1 1h]", services)
+	}
+	if len(down) != 0 {
+		t.Fatalf("down = %v, want no stale ephemeral instances", down)
+	}
+}
+
+func TestSummarizeServices_reportsStaleReplicaSlotAsDown(t *testing.T) {
+	// Given
+	now := time.Date(2026, 8, 2, 12, 0, 0, 0, time.UTC)
+	statuses := []uptime.InstanceStatus{
+		{
+			Service:   "eventsub",
+			Instance:  "slot-2",
+			StartedAt: now.Add(-time.Hour),
+			UpdatedAt: now.Add(-2 * time.Minute),
+		},
+	}
+
+	// When
+	services, down, _ := summarizeServices(statuses, now, "unavailable")
+
+	// Then
+	if len(services) != 1 || services[0] != "eventsub×0 unavailable" {
+		t.Fatalf("services = %v, want [eventsub×0 unavailable]", services)
+	}
+	if len(down) != 1 || down[0] != "eventsub#2" {
+		t.Fatalf("down = %v, want [eventsub#2]", down)
+	}
+}

--- a/docker-compose.stack.yml
+++ b/docker-compose.stack.yml
@@ -339,6 +339,8 @@ services:
     image: registry.twir.app/twirapp/api-gql:${TWIR_IMAGE_TAG:-latest}
     secrets:
       - twir_doppler_token
+    environment:
+      REPLICA: "{{.Task.Slot}}"
     networks:
       - twir
       - traefik-public
@@ -412,6 +414,8 @@ services:
     image: registry.twir.app/twirapp/bots:${TWIR_IMAGE_TAG:-latest}
     secrets:
       - twir_doppler_token
+    environment:
+      REPLICA: "{{.Task.Slot}}"
     networks:
       - traefik-public
       - twir
@@ -442,6 +446,8 @@ services:
     image: registry.twir.app/twirapp/parser:${TWIR_IMAGE_TAG:-latest}
     secrets:
       - twir_doppler_token
+    environment:
+      REPLICA: "{{.Task.Slot}}"
     deploy:
       update_config:
         parallelism: 2
@@ -463,6 +469,8 @@ services:
     image: registry.twir.app/twirapp/timers:${TWIR_IMAGE_TAG:-latest}
     secrets:
       - twir_doppler_token
+    environment:
+      REPLICA: "{{.Task.Slot}}"
     networks:
       - twir
     deploy:
@@ -484,6 +492,8 @@ services:
     image: registry.twir.app/twirapp/scheduler:${TWIR_IMAGE_TAG:-latest}
     secrets:
       - twir_doppler_token
+    environment:
+      REPLICA: "{{.Task.Slot}}"
     networks:
       - twir
     deploy:
@@ -701,6 +711,8 @@ services:
     image: registry.twir.app/twirapp/websockets:${TWIR_IMAGE_TAG:-latest}
     secrets:
       - twir_doppler_token
+    environment:
+      REPLICA: "{{.Task.Slot}}"
     networks:
       - twir
       - traefik-public
@@ -741,6 +753,8 @@ services:
     image: registry.twir.app/twirapp/tokens:${TWIR_IMAGE_TAG:-latest}
     secrets:
       - twir_doppler_token
+    environment:
+      REPLICA: "{{.Task.Slot}}"
     networks:
       - twir
     deploy:
@@ -762,6 +776,8 @@ services:
     image: registry.twir.app/twirapp/emotes-cacher:${TWIR_IMAGE_TAG:-latest}
     secrets:
       - twir_doppler_token
+    environment:
+      REPLICA: "{{.Task.Slot}}"
     networks:
       - twir
     deploy:
@@ -786,6 +802,8 @@ services:
     image: registry.twir.app/twirapp/events:${TWIR_IMAGE_TAG:-latest}
     secrets:
       - twir_doppler_token
+    environment:
+      REPLICA: "{{.Task.Slot}}"
     networks:
       - twir
     deploy:

--- a/libs/uptime/reader.go
+++ b/libs/uptime/reader.go
@@ -12,6 +12,8 @@ import (
 	rediskeys "github.com/twirapp/twir/libs/redis_keys"
 )
 
+const scanCount int64 = 1000
+
 type InstanceStatus struct {
 	Service   string
 	Instance  string
@@ -81,7 +83,7 @@ func readKeys(ctx context.Context, client *redis.Client) ([]string, error) {
 	keys := []string{}
 	var cursor uint64
 	for {
-		batch, nextCursor, err := client.Scan(ctx, cursor, rediskeys.UptimeScanPattern, 0).Result()
+		batch, nextCursor, err := client.Scan(ctx, cursor, rediskeys.UptimeScanPattern, scanCount).Result()
 		if err != nil {
 			return nil, fmt.Errorf("scan cursor %d: %w", cursor, err)
 		}


### PR DESCRIPTION
## Summary

- ignore stale ephemeral Swarm hostnames left by rolling deployments
- identify production service instances by stable replica slots
- speed up Redis uptime-key scanning and cap platform ping latency at one second
- keep down reporting for stale stable replica slots

## Verification

- go test ./internal/commands/stats
- go test ./... in libs/uptime
- go test -vet=off ./... in apps/parser
- docker compose -f docker-compose.stack.yml config --quiet

The regular full parser test run is still blocked by pre-existing vet failures for non-constant format strings in unrelated packages.