### PR TITLE
fix(bots): skip ambiguous cyrillic translations

### DIFF
--- a/apps/bots/internal/services/chat_translations/chat_translations.go
+++ b/apps/bots/internal/services/chat_translations/chat_translations.go
@@ -217,6 +217,21 @@ func (c *Service) Handle(ctx context.Context, input ChatMessageInput) error {
 		return nil
 	}
 
+	if isAmbiguousCyrillicDetection(
+		textForTranslate,
+		msgLang.Language,
+		channelTranslationSettings.TargetLanguage,
+	) {
+		c.logger.Info(
+			"skipping translation: ambiguous cyrillic language detection",
+			slog.String("detected_lang", msgLang.Language),
+			slog.Float64("confidence", msgLang.Confidence),
+			slog.String("target_lang", channelTranslationSettings.TargetLanguage),
+			slog.String("text", textForTranslate),
+		)
+		return nil
+	}
+
 	if slices.Contains(channelTranslationSettings.ExcludedLanguages, msgLang.Language) {
 		return nil
 	}
@@ -243,7 +258,7 @@ func (c *Service) Handle(ctx context.Context, input ChatMessageInput) error {
 		return nil
 	}
 
-	if res.TranslatedText[0] == textForTranslate {
+	if translationsEquivalent(textForTranslate, res.TranslatedText[0]) {
 		return nil
 	}
 

--- a/apps/bots/internal/services/chat_translations/script_guard.go
+++ b/apps/bots/internal/services/chat_translations/script_guard.go
@@ -1,0 +1,73 @@
+package chat_translations
+
+import (
+	"strings"
+	"unicode"
+)
+
+// cyrillicAlphabets lists the lowercase letters of Cyrillic-script languages
+// supported by the language detector. It is used to sanity-check detections:
+// short Cyrillic messages are frequently misclassified between these
+// languages (e.g. Russian detected as Bulgarian with confidence ~0.25).
+var cyrillicAlphabets = map[string]string{
+	"ru": "абвгдеёжзийклмнопрстуфхцчшщъыьэюя",
+	"uk": "абвгґдеєжзиіїйклмнопрстуфхцчшщьюя",
+	"be": "абвгдеёжзійклмнопрстуўфхцчшыьэюя",
+	"bg": "абвгдежзийклмнопрстуфхцчшщъьюя",
+	"sr": "абвгдђежзијклљмнњопрстћуфхцчџш",
+	"mk": "абвгдѓежзијклљмнњопрстќуфхцчџшѕ",
+	"kk": "аәбвгғдеёжзийкқлмнңоөпрстуұүфхһцчшщъыіьэюя",
+	"tg": "абвгғдеёжзиӣйкқлмнопрстуфхҳҷцчшъэюя",
+	"mn": "абвгдеёжзийклмноөпрстуүфхцчшщъыьэюя",
+	"ky": "абвгдеёжзийклмнңоөпрстуүфхцчшщъыьэюя",
+}
+
+// isAmbiguousCyrillicDetection reports whether a detected Cyrillic language
+// cannot be distinguished from the target language by the letters actually
+// present in the text (e.g. Russian "чай попей" misdetected as Bulgarian).
+// It is true when the text has no letter unique to the detected alphabet, or
+// has a letter impossible in it. Tradeoff: genuine messages in closely
+// related languages without distinguishing letters are skipped too, but
+// translating them produces near-identical text anyway.
+func isAmbiguousCyrillicDetection(text, detectedLang, targetLang string) bool {
+	if detectedLang == targetLang {
+		return false
+	}
+
+	detectedAlphabet, ok := cyrillicAlphabets[detectedLang]
+	if !ok {
+		return false
+	}
+	targetAlphabet, ok := cyrillicAlphabets[targetLang]
+	if !ok {
+		return false
+	}
+
+	hasCyrillic := false
+	evidenceForDetected := false
+
+	for _, r := range strings.ToLower(text) {
+		if !unicode.IsLetter(r) || !unicode.In(r, unicode.Cyrillic) {
+			continue
+		}
+
+		hasCyrillic = true
+		inDetected := strings.ContainsRune(detectedAlphabet, r)
+		inTarget := strings.ContainsRune(targetAlphabet, r)
+
+		if !inDetected && inTarget {
+			// the letter cannot exist in the detected language,
+			// but is valid in the target one
+			return true
+		}
+		if inDetected && !inTarget {
+			evidenceForDetected = true
+		}
+	}
+
+	if !hasCyrillic {
+		return false
+	}
+
+	return !evidenceForDetected
+}

--- a/apps/bots/internal/services/chat_translations/script_guard_test.go
+++ b/apps/bots/internal/services/chat_translations/script_guard_test.go
@@ -1,0 +1,49 @@
+package chat_translations
+
+import "testing"
+
+func TestIsAmbiguousCyrillicDetection(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		text     string
+		detected string
+		target   string
+		want     bool
+	}{
+		{name: "russian misdetected as bulgarian", text: "чай попей", detected: "bg", target: "ru", want: true},
+		{name: "russian with exclamation misdetected as bulgarian", text: "дайте токенов!", detected: "bg", target: "ru", want: true},
+		{name: "short russian misdetected as bulgarian", text: "да не", detected: "bg", target: "ru", want: true},
+		{name: "russian misdetected as serbian", text: "как дела братан", detected: "sr", target: "ru", want: true},
+		{name: "russian misdetected as kazakh", text: "ёпта", detected: "kk", target: "ru", want: true},
+		{name: "ukrainian with unique letters detected as ukrainian", text: "слава україні", detected: "uk", target: "ru", want: false},
+		{name: "russian-only letter contradicts ukrainian detection", text: "привет ёж", detected: "uk", target: "ru", want: true},
+		{name: "russian-only letter contradicts bulgarian detection", text: "эх ты", detected: "bg", target: "ru", want: true},
+		{name: "serbian with unique letters detected as serbian", text: "ћао брате", detected: "sr", target: "ru", want: false},
+		{name: "mixed cyrillic and latin with evidence for detected", text: "слава україні lol", detected: "uk", target: "ru", want: false},
+		{name: "latin text is out of scope", text: "hello world", detected: "de", target: "ru", want: false},
+		{name: "same language is handled earlier", text: "чай попей", detected: "ru", target: "ru", want: false},
+		{name: "unknown detected language passes through", text: "чай попей", detected: "xx", target: "ru", want: false},
+		{name: "non cyrillic target passes through", text: "чай попей", detected: "bg", target: "en", want: false},
+		{name: "bulgarian without distinguishing letters is skipped by design", text: "добър ден", detected: "bg", target: "ru", want: true},
+		{name: "kazakh with unique letters detected as kazakh", text: "сәлем қалайсың", detected: "kk", target: "ru", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := isAmbiguousCyrillicDetection(tt.text, tt.detected, tt.target); got != tt.want {
+				t.Fatalf(
+					"isAmbiguousCyrillicDetection(%q, %q, %q) = %t, want %t",
+					tt.text,
+					tt.detected,
+					tt.target,
+					got,
+					tt.want,
+				)
+			}
+		})
+	}
+}

--- a/apps/bots/internal/services/chat_translations/translate.go
+++ b/apps/bots/internal/services/chat_translations/translate.go
@@ -38,6 +38,58 @@ func hasTranslatableText(text string) bool {
 	return letters >= 3
 }
 
+// translationsEquivalent reports whether a translation is a near-copy of the
+// source, which happens when the source language was misdetected.
+func translationsEquivalent(source, translated string) bool {
+	src := lettersOnlyRunes(source)
+	dst := lettersOnlyRunes(translated)
+
+	if len(src) == 0 || len(dst) == 0 {
+		return false
+	}
+
+	distance := levenshteinDistance(src, dst)
+	similarity := 1 - float64(distance)/float64(max(len(src), len(dst)))
+
+	return similarity >= 0.8
+}
+
+func lettersOnlyRunes(text string) []rune {
+	runes := make([]rune, 0, len(text))
+	for _, r := range strings.ToLower(text) {
+		if unicode.IsLetter(r) {
+			runes = append(runes, r)
+		}
+	}
+	return runes
+}
+
+func levenshteinDistance(s1, s2 []rune) int {
+	previous := make([]int, len(s2)+1)
+	for j := range previous {
+		previous[j] = j
+	}
+
+	for i := 1; i <= len(s1); i++ {
+		current := make([]int, len(s2)+1)
+		current[0] = i
+		for j := 1; j <= len(s2); j++ {
+			cost := 1
+			if s1[i-1] == s2[j-1] {
+				cost = 0
+			}
+			current[j] = min(
+				previous[j-1]+cost,
+				previous[j]+1,
+				current[j-1]+1,
+			)
+		}
+		previous = current
+	}
+
+	return previous[len(s2)]
+}
+
 type translateRequest struct {
 	Text          string   `json:"text"`
 	SrcLang       string   `json:"src"`
@@ -59,7 +111,7 @@ func (c *Service) translate(
 	start := time.Now()
 
 	cacheKey := fmt.Sprintf(
-		"chat-translator:%s",
+		"chat-translator:v2:%s",
 		base64.StdEncoding.EncodeToString(
 			[]byte(fmt.Sprintf(
 				"%s:%s:%s",

--- a/apps/bots/internal/services/chat_translations/translate_test.go
+++ b/apps/bots/internal/services/chat_translations/translate_test.go
@@ -67,3 +67,38 @@ func TestHasTranslatableText(t *testing.T) {
 		})
 	}
 }
+
+func TestTranslationsEquivalent(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		source     string
+		translated string
+		want       bool
+	}{
+		{name: "identical text", source: "hello world", translated: "hello world", want: true},
+		{name: "case and punctuation shuffle", source: "чай попей", translated: "чай Попай", want: true},
+		{name: "single letter suffix", source: "да не", translated: "да нет", want: true},
+		{name: "different punctuation only", source: "привет, как дела?", translated: "Привет как дела", want: true},
+		{name: "synonym swap is not equivalent", source: "дайте токенов!", translated: "Дайте мне жетон!", want: false},
+		{name: "real translation", source: "hello my friend", translated: "привет мой друг", want: false},
+		{name: "empty source", source: "!!!", translated: "???", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := translationsEquivalent(tt.source, tt.translated); got != tt.want {
+				t.Fatalf(
+					"translationsEquivalent(%q, %q) = %t, want %t",
+					tt.source,
+					tt.translated,
+					got,
+					tt.want,
+				)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to #1030 — lingua still misdetects short Cyrillic messages as other Cyrillic languages ("чай попей" → Bulgarian @ 0.25 confidence, "дайте токенов!" → bg @ 0.42, "да не" → bg @ 0.16), so the bot kept posting garbled "translations" like "чай Попай" / "Дайте мне жетон!". A raw confidence threshold can't fix this: legitimate short phrases score just as low ("ciao bella" → 0.12).

- sanity-check Cyrillic detections against language alphabets: skip when the text has no letters unique to the detected language (or has letters impossible in it). Ukrainian/Serbian/Kazakh with distinguishing letters (ї, ћ, ә…) still translate
- skip posting translations that are near-copies of the source (letter-normalized Levenshtein ≥ 0.8) — catches "чай Попай"-style garbage for any language pair
- bump translation cache key to v2 to drop poisoned 7-day entries

Tradeoff: genuine Bulgarian in a ru-targeted channel without distinguishing letters is skipped too, but bg→ru translations are near-identical anyway.

## Testing

- `go test ./internal/services/chat_translations/ -count=1` — 35/35 pass, including every phrase from the reported chat log
- verified live against the language-processor: all reported messages detect as bg/sr/kk and are now skipped before translation