### PR TITLE
feat(web): add AI MCP feature to landing and compare table

### DIFF
--- a/web/i18n/locales/de.json
+++ b/web/i18n/locales/de.json
@@ -1458,7 +1458,8 @@
       "vipManagement": "VIP-Verwaltung",
       "emoteStats": "Emote-Statistiken",
       "musicRecognition": "Musikerkennung (Shazam-ähnlich)",
-      "obsIntegration": "OBS-Integration"
+      "obsIntegration": "OBS-Integration",
+      "aiMcp": "KI-Steuerung (MCP)"
     },
     "notes": {
       "overlaysTwir": "Now Playing, Chat, Faceit- & Valorant-Stats, Emote Wall, Pixel Dudes, AFK und mehr",
@@ -1480,7 +1481,8 @@
       "rolesMoobot": "1 Berechtigungsgruppe im kostenlosen Plan",
       "vipTwir": "VIPs verwalten und Ablauf planen",
       "vipMoobot": "Nur First Wave VIP, MoobotPlus (kostenpflichtig)",
-      "obsTwir": "Szenen wechseln, Audio stummschalten, Quellen umschalten via Websockets"
+      "obsTwir": "Szenen wechseln, Audio stummschalten, Quellen umschalten via Websockets",
+      "aiMcpTwir": "Bot über Claude Code, Codex, OpenCode und andere KI-Assistenten via MCP verwalten"
     },
     "values": {
       "platforms": {

--- a/web/i18n/locales/en.json
+++ b/web/i18n/locales/en.json
@@ -1783,7 +1783,8 @@
       "vipManagement": "VIP management",
       "emoteStats": "Emote statistics",
       "musicRecognition": "Music recognition (Shazam-like)",
-      "obsIntegration": "OBS integration"
+      "obsIntegration": "OBS integration",
+      "aiMcp": "AI control (MCP)"
     },
     "notes": {
       "overlaysTwir": "Now Playing, Chat, Faceit & Valorant stats, Emote Wall, Pixel Dudes, AFK and more",
@@ -1805,7 +1806,8 @@
       "rolesMoobot": "1 permission group on the free plan",
       "vipTwir": "Manage VIPs and schedule VIP expiration",
       "vipMoobot": "First Wave VIP only, MoobotPlus (paid)",
-      "obsTwir": "Change scenes, mute audio, toggle sources via websockets"
+      "obsTwir": "Change scenes, mute audio, toggle sources via websockets",
+      "aiMcpTwir": "Manage the bot from Claude Code, Codex, OpenCode and other AI assistants via MCP"
     },
     "values": {
       "platforms": {

--- a/web/i18n/locales/es.json
+++ b/web/i18n/locales/es.json
@@ -1458,7 +1458,8 @@
       "vipManagement": "Gestión de VIP",
       "emoteStats": "Estadísticas de emotes",
       "musicRecognition": "Reconocimiento de música (tipo Shazam)",
-      "obsIntegration": "Integración con OBS"
+      "obsIntegration": "Integración con OBS",
+      "aiMcp": "Control con IA (MCP)"
     },
     "notes": {
       "overlaysTwir": "Now Playing, Chat, estadísticas de Faceit y Valorant, Emote Wall, Pixel Dudes, AFK y más",
@@ -1480,7 +1481,8 @@
       "rolesMoobot": "1 grupo de permisos en el plan gratuito",
       "vipTwir": "Gestiona VIPs y programa su expiración",
       "vipMoobot": "Solo First Wave VIP, MoobotPlus (de pago)",
-      "obsTwir": "Cambia escenas, silencia audio y alterna fuentes vía websockets"
+      "obsTwir": "Cambia escenas, silencia audio y alterna fuentes vía websockets",
+      "aiMcpTwir": "Gestiona el bot desde Claude Code, Codex, OpenCode y otros asistentes de IA mediante MCP"
     },
     "values": {
       "platforms": {

--- a/web/i18n/locales/ja.json
+++ b/web/i18n/locales/ja.json
@@ -100,7 +100,8 @@
       "vipManagement": "VIP 管理",
       "emoteStats": "エモート統計",
       "musicRecognition": "音楽認識（Shazam 風）",
-      "obsIntegration": "OBS 連携"
+      "obsIntegration": "OBS 連携",
+      "aiMcp": "AI コントロール (MCP)"
     },
     "notes": {
       "overlaysTwir": "Now Playing、チャット、Faceit・Valorant スタッツ、Emote Wall、Pixel Dudes、AFK など",
@@ -122,7 +123,8 @@
       "rolesMoobot": "無料プランでは権限グループ1つ",
       "vipTwir": "VIP の管理と有効期限のスケジュール",
       "vipMoobot": "First Wave VIP のみ、MoobotPlus（有料）",
-      "obsTwir": "WebSockets でシーン切替・ミュート・ソース表示切替"
+      "obsTwir": "WebSockets でシーン切替・ミュート・ソース表示切替",
+      "aiMcpTwir": "Claude Code、Codex、OpenCode などの AI アシスタントから MCP 経由でボットを管理"
     },
     "values": {
       "platforms": {

--- a/web/i18n/locales/pt.json
+++ b/web/i18n/locales/pt.json
@@ -1458,7 +1458,8 @@
       "vipManagement": "Gestão de VIP",
       "emoteStats": "Estatísticas de emotes",
       "musicRecognition": "Reconhecimento de música (tipo Shazam)",
-      "obsIntegration": "Integração com OBS"
+      "obsIntegration": "Integração com OBS",
+      "aiMcp": "Controlo por IA (MCP)"
     },
     "notes": {
       "overlaysTwir": "Now Playing, Chat, estatísticas de Faceit e Valorant, Emote Wall, Pixel Dudes, AFK e mais",
@@ -1480,7 +1481,8 @@
       "rolesMoobot": "1 grupo de permissões no plano gratuito",
       "vipTwir": "Gerencie VIPs e programe a expiração",
       "vipMoobot": "Apenas First Wave VIP, MoobotPlus (pago)",
-      "obsTwir": "Mude cenas, silencie áudio e alterne fontes via websockets"
+      "obsTwir": "Mude cenas, silencie áudio e alterne fontes via websockets",
+      "aiMcpTwir": "Gira o bot a partir do Claude Code, Codex, OpenCode e outros assistentes de IA via MCP"
     },
     "values": {
       "platforms": {

--- a/web/i18n/locales/ru.json
+++ b/web/i18n/locales/ru.json
@@ -1669,7 +1669,8 @@
       "vipManagement": "Управление VIP",
       "emoteStats": "Статистика смайлов",
       "musicRecognition": "Распознавание музыки (как Shazam)",
-      "obsIntegration": "Интеграция с OBS"
+      "obsIntegration": "Интеграция с OBS",
+      "aiMcp": "Управление через ИИ (MCP)"
     },
     "notes": {
       "overlaysTwir": "Now Playing, Чат, статистика Faceit и Valorant, Emote Wall, Pixel Dudes, AFK и другие",
@@ -1691,7 +1692,8 @@
       "rolesMoobot": "1 группа прав на бесплатном плане",
       "vipTwir": "Управление VIP и планирование снятия по времени",
       "vipMoobot": "Только First Wave VIP, MoobotPlus (платно)",
-      "obsTwir": "Смена сцен, мьют звука, видимость источников через websockets"
+      "obsTwir": "Смена сцен, мьют звука, видимость источников через websockets",
+      "aiMcpTwir": "Управляйте ботом из Claude Code, Codex, OpenCode и других ИИ-ассистентов через MCP"
     },
     "values": {
       "platforms": {

--- a/web/i18n/locales/sk.json
+++ b/web/i18n/locales/sk.json
@@ -1458,7 +1458,8 @@
       "vipManagement": "Správa VIP",
       "emoteStats": "Štatistiky emotov",
       "musicRecognition": "Rozpoznávanie hudby (ako Shazam)",
-      "obsIntegration": "Integrácia s OBS"
+      "obsIntegration": "Integrácia s OBS",
+      "aiMcp": "Ovládanie pomocou AI (MCP)"
     },
     "notes": {
       "overlaysTwir": "Now Playing, Chat, Faceit a Valorant štatistiky, Emote Wall, Pixel Dudes, AFK a ďalšie",
@@ -1480,7 +1481,8 @@
       "rolesMoobot": "1 skupina oprávnení v bezplatnom pláne",
       "vipTwir": "Správa VIP a plánovanie expirácie",
       "vipMoobot": "Len First Wave VIP, MoobotPlus (platené)",
-      "obsTwir": "Zmena scén, stlmenie zvuku, viditeľnosť zdrojov cez websockets"
+      "obsTwir": "Zmena scén, stlmenie zvuku, viditeľnosť zdrojov cez websockets",
+      "aiMcpTwir": "Spravujte bota z Claude Code, Codex, OpenCode a ďalších AI asistentov cez MCP"
     },
     "values": {
       "platforms": {

--- a/web/i18n/locales/uk.json
+++ b/web/i18n/locales/uk.json
@@ -1470,7 +1470,8 @@
       "vipManagement": "Керування VIP",
       "emoteStats": "Статистика смайлів",
       "musicRecognition": "Розпізнавання музики (як Shazam)",
-      "obsIntegration": "Інтеграція з OBS"
+      "obsIntegration": "Інтеграція з OBS",
+      "aiMcp": "Керування через ШІ (MCP)"
     },
     "notes": {
       "overlaysTwir": "Now Playing, Чат, статистика Faceit та Valorant, Emote Wall, Pixel Dudes, AFK та інші",
@@ -1492,7 +1493,8 @@
       "rolesMoobot": "1 група прав на безкоштовному плані",
       "vipTwir": "Керування VIP та планування зняття за часом",
       "vipMoobot": "Лише First Wave VIP, MoobotPlus (платно)",
-      "obsTwir": "Зміна сцен, мʼют звуку, видимість джерел через websockets"
+      "obsTwir": "Зміна сцен, мʼют звуку, видимість джерел через websockets",
+      "aiMcpTwir": "Керуйте ботом із Claude Code, Codex, OpenCode та інших ШІ-асистентів через MCP"
     },
     "values": {
       "platforms": {

--- a/web/layers/landing/components/compare/compare.data.ts
+++ b/web/layers/landing/components/compare/compare.data.ts
@@ -213,6 +213,16 @@ export const compareFeatureRows: CompareFeatureRow[] = [
 		},
 	},
 	{
+		labelKey: 'compare.features.aiMcp',
+		cells: {
+			twir: yes('compare.notes.aiMcpTwir'),
+			nightbot: no(),
+			streamelements: no(),
+			moobot: no(),
+			fossabot: no(),
+		},
+	},
+	{
 		labelKey: 'compare.features.openSource',
 		cells: {
 			twir: yes('compare.notes.openSourceTwir'),

--- a/web/layers/landing/components/index/features/features-data.ts
+++ b/web/layers/landing/components/index/features/features-data.ts
@@ -57,6 +57,13 @@ export const featuresData: Feature[] = [
 		icon: h(Icon, { name: 'lucide:code' }),
 	},
 	{
+		id: 'mcp',
+		title: 'AI control (MCP)',
+		description:
+			'Control your bot with AI assistants: manage commands, timers, keywords, variables and more from Claude Code, Codex or OpenCode via MCP',
+		icon: h(Icon, { name: 'lucide:bot' }),
+	},
+	{
 		id: 'timers',
 		title: 'Timers',
 		description:


### PR DESCRIPTION
## Summary

Adds the existing AI MCP capability to marketing surfaces:

- **Landing features list** (`/`): new `AI control (MCP)` card with `lucide:bot` icon (same icon as dashboard MCP nav item)
- **Compare page** (`/compare`): new `AI control (MCP)` row — Twir: yes (with note), Nightbot / StreamElements / Moobot / Fossabot: no
- **i18n**: `compare.features.aiMcp` + `compare.notes.aiMcpTwir` keys added for all 8 locales (en, ru, uk, de, es, pt, sk, ja)

## Verification

- `oxlint` clean on changed TS files
- Locale diffs are minimal (+2 keys each, formatting preserved)