### PR TITLE
fix(deploy): wait for service convergence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -334,6 +334,23 @@ const integrationsPage = useIntegrationsPageData()
 
 ### **7. Go (Golang) Backend**
 
+- **Fx lifecycle contexts (mandatory):**
+  - Treat the `context.Context` passed to `fx.Hook.OnStart` and `fx.Hook.OnStop` as a short-lived,
+    phase-scoped deadline context owned by Fx.
+  - **NEVER** store that context in a struct, capture/pass it to a background goroutine, or reuse it
+    after the hook returns. It is canceled when the lifecycle phase finishes or times out.
+  - Long-running workers must use their own service-owned context (for example,
+    `context.WithCancel(context.Background())`). Start the worker in `OnStart`, retain its cancel
+    function, cancel it in `OnStop`, and wait for the worker to exit within the `OnStop` context.
+  - Use the Fx context only for bounded synchronous startup/shutdown work inside the hook. Do not
+    replace it with `context.Background()` or `context.TODO()` for such work, because that bypasses
+    Fx cancellation and can leave a hook running after startup has failed.
+  - `OnStart` must return quickly. Do not perform unbounded loops, bulk reconciliation, or
+    sequential calls to external services there; move those to a managed background worker unless
+    they are strictly required for readiness and have explicit bounded timeouts.
+  - Do not raise `fx.StartTimeout` or `fx.StopTimeout` merely to hide a slow or stuck hook. Increase
+    them only when the bounded lifecycle operation is intentionally required and the longer budget
+    is documented.
 - **Migrations**
   - If need to create new database migration for your task, use:
   - command `bun cli m create --name value --db postgres|clickhouse --type sql|go`

--- a/cli/internal/cmds/deploy/deploy.go
+++ b/cli/internal/cmds/deploy/deploy.go
@@ -21,9 +21,18 @@ import (
 )
 
 const (
-	defaultStackName = "twir"
-	defaultRegistry  = "registry.twir.app"
+	defaultStackName          = "twir"
+	defaultRegistry           = "registry.twir.app"
+	serviceUpdatePollInterval = time.Second
 )
+
+type serviceInspector interface {
+	ServiceInspectWithRaw(
+		context.Context,
+		string,
+		swarm.ServiceInspectOptions,
+	) (swarm.Service, []byte, error)
+}
 
 var serviceImages = map[string]string{
 	"migrations":     "migrations",
@@ -389,8 +398,68 @@ func updateServiceImage(ctx context.Context, cfg deployConfig, serviceName strin
 	if err != nil {
 		return deployResult{Service: serviceName, Image: image, Status: "failed"}, fmt.Errorf("update swarm service: %w", err)
 	}
+	if err := waitForServiceUpdate(
+		ctx,
+		dockerClient,
+		service.ID,
+		service.Version.Index,
+		serviceUpdatePollInterval,
+	); err != nil {
+		return deployResult{Service: serviceName, Image: image, Status: "failed"}, err
+	}
 
 	return deployResult{Service: serviceName, Image: image, Status: "updated"}, nil
+}
+
+func waitForServiceUpdate(
+	ctx context.Context,
+	inspector serviceInspector,
+	serviceID string,
+	previousVersion uint64,
+	pollInterval time.Duration,
+) error {
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+
+	var lastStatus string
+	for {
+		service, _, err := inspector.ServiceInspectWithRaw(
+			ctx,
+			serviceID,
+			swarm.ServiceInspectOptions{},
+		)
+		if err != nil {
+			return fmt.Errorf("inspect swarm service update: %w", err)
+		}
+
+		if service.Version.Index > previousVersion && service.UpdateStatus != nil {
+			status := service.UpdateStatus
+			lastStatus = string(status.State)
+			if status.Message != "" {
+				lastStatus += ": " + status.Message
+			}
+
+			switch status.State {
+			case swarm.UpdateStateCompleted:
+				return nil
+			case swarm.UpdateStatePaused:
+				return fmt.Errorf("swarm service update paused: %s", status.Message)
+			case swarm.UpdateStateRollbackPaused:
+				return fmt.Errorf("swarm service rollback paused: %s", status.Message)
+			case swarm.UpdateStateRollbackCompleted:
+				return fmt.Errorf("swarm service update rolled back: %s", status.Message)
+			}
+		}
+
+		select {
+		case <-ctx.Done():
+			if lastStatus == "" {
+				lastStatus = "status unavailable"
+			}
+			return fmt.Errorf("wait for swarm service update (%s): %w", lastStatus, ctx.Err())
+		case <-ticker.C:
+		}
+	}
 }
 
 func findService(ctx context.Context, dockerClient *client.Client, stackName string, serviceName string) (swarm.Service, error) {

--- a/cli/internal/cmds/deploy/deploy_test.go
+++ b/cli/internal/cmds/deploy/deploy_test.go
@@ -1,0 +1,102 @@
+package deploy
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/docker/docker/api/types/swarm"
+)
+
+type fakeServiceInspector struct {
+	services []swarm.Service
+	err      error
+	index    int
+}
+
+func (f *fakeServiceInspector) ServiceInspectWithRaw(
+	context.Context,
+	string,
+	swarm.ServiceInspectOptions,
+) (swarm.Service, []byte, error) {
+	if f.err != nil {
+		return swarm.Service{}, nil, f.err
+	}
+
+	index := min(f.index, len(f.services)-1)
+	service := f.services[index]
+	f.index++
+	return service, nil, nil
+}
+
+func serviceWithUpdate(version uint64, state swarm.UpdateState, message string) swarm.Service {
+	return swarm.Service{
+		Meta: swarm.Meta{Version: swarm.Version{Index: version}},
+		UpdateStatus: &swarm.UpdateStatus{
+			State:   state,
+			Message: message,
+		},
+	}
+}
+
+func TestWaitForServiceUpdateCompletes(t *testing.T) {
+	inspector := &fakeServiceInspector{services: []swarm.Service{
+		serviceWithUpdate(10, swarm.UpdateStateCompleted, "previous update"),
+		serviceWithUpdate(11, swarm.UpdateStateUpdating, "update in progress"),
+		serviceWithUpdate(11, swarm.UpdateStateCompleted, "update completed"),
+	}}
+
+	err := waitForServiceUpdate(t.Context(), inspector, "service-id", 10, time.Millisecond)
+	if err != nil {
+		t.Fatalf("waitForServiceUpdate() error = %v", err)
+	}
+}
+
+func TestWaitForServiceUpdateReportsTerminalFailure(t *testing.T) {
+	tests := []struct {
+		name      string
+		state     swarm.UpdateState
+		wantError string
+	}{
+		{name: "paused", state: swarm.UpdateStatePaused, wantError: "update paused"},
+		{name: "rollback paused", state: swarm.UpdateStateRollbackPaused, wantError: "rollback paused"},
+		{name: "rolled back", state: swarm.UpdateStateRollbackCompleted, wantError: "update rolled back"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inspector := &fakeServiceInspector{services: []swarm.Service{
+				serviceWithUpdate(11, tt.state, "task failed"),
+			}}
+
+			err := waitForServiceUpdate(t.Context(), inspector, "service-id", 10, time.Millisecond)
+			if err == nil || !strings.Contains(err.Error(), tt.wantError) {
+				t.Fatalf("waitForServiceUpdate() error = %v, want containing %q", err, tt.wantError)
+			}
+		})
+	}
+}
+
+func TestWaitForServiceUpdateReportsInspectFailure(t *testing.T) {
+	inspector := &fakeServiceInspector{err: errors.New("daemon unavailable")}
+
+	err := waitForServiceUpdate(t.Context(), inspector, "service-id", 10, time.Millisecond)
+	if err == nil || !strings.Contains(err.Error(), "inspect swarm service update") {
+		t.Fatalf("waitForServiceUpdate() error = %v", err)
+	}
+}
+
+func TestWaitForServiceUpdateHonorsContext(t *testing.T) {
+	inspector := &fakeServiceInspector{services: []swarm.Service{
+		serviceWithUpdate(11, swarm.UpdateStateUpdating, "update in progress"),
+	}}
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Millisecond)
+	defer cancel()
+
+	err := waitForServiceUpdate(ctx, inspector, "service-id", 10, time.Millisecond)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("waitForServiceUpdate() error = %v, want context deadline exceeded", err)
+	}
+}


### PR DESCRIPTION
## Summary

- wait for each Docker Swarm service update to converge before updating the next service
- report paused and rolled-back updates as deployment failures
- document mandatory Fx lifecycle context rules
- cover rollout state handling with unit tests

## Why

Services use `update_config.order: start-first`, so Swarm temporarily runs old and new tasks together. The deploy CLI previously returned immediately after `ServiceUpdate`, causing every affected service to roll at once. This produced counts such as `bots 6/4` (`4` desired plus update parallelism `2`) and `scheduler 2/1`.

Waiting for terminal update state limits overlap to the service currently being deployed and prevents a paused or rolled-back rollout from being reported as successful.

## Verification

- `go test ./...` in `cli/`
- `go build ./...` in `cli/`
- `go vet ./internal/cmds/deploy` in `cli/`
- `git diff --check`