### PR TITLE
fix(eventsub): don't fail app startup on conduit lock contention

### DIFF
--- a/apps/eventsub/internal/manager/manager.go
+++ b/apps/eventsub/internal/manager/manager.go
@@ -47,6 +47,9 @@ type Manager struct {
 
 	wsCurrentSessionId *string
 	currentConduit     *conduitsResponseConduit
+
+	workerCancel context.CancelFunc
+	workerDone   chan struct{}
 }
 
 type Opts struct {
@@ -80,6 +83,8 @@ func NewManager(opts Opts) (*Manager, error) {
 		apiBaseUrl = "https://api.twitch.tv"
 	}
 
+	workerCtx, workerCancel := context.WithCancel(context.Background())
+
 	manager := &Manager{
 		config:             opts.Config,
 		logger:             opts.Logger,
@@ -96,17 +101,29 @@ func NewManager(opts Opts) (*Manager, error) {
 		wsOpts:             wsOpts,
 		wsCurrentSessionId: nil,
 		currentConduit:     nil,
+		workerCancel:       workerCancel,
+		workerDone:         make(chan struct{}),
 	}
 
 	opts.Lc.Append(
 		fx.Hook{
 			OnStart: func(ctx context.Context) error {
-				if err := manager.createConduit(); err != nil {
-					return err
-				}
-				go manager.startWebSocket()
+				go func() {
+					defer close(manager.workerDone)
+					manager.runStartup(workerCtx)
+				}()
 
 				return nil
+			},
+			OnStop: func(ctx context.Context) error {
+				workerCancel()
+
+				select {
+				case <-manager.workerDone:
+					return nil
+				case <-ctx.Done():
+					return ctx.Err()
+				}
 			},
 		},
 	)

--- a/apps/eventsub/internal/manager/on_start.go
+++ b/apps/eventsub/internal/manager/on_start.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"time"
 
 	"github.com/kvizyx/twitchy/eventsub"
 	"github.com/twirapp/twir/libs/bus-core/tokens"
@@ -35,9 +36,33 @@ type createConduitResponse struct {
 	Data []conduitsResponseConduit `json:"data"`
 }
 
-func (c *Manager) createConduit() error {
-	ctx := context.TODO()
+func (c *Manager) runStartup(ctx context.Context) {
+	for {
+		if err := c.createConduit(ctx); err != nil {
+			if ctx.Err() != nil {
+				return
+			}
 
+			c.logger.Error("failed to ensure conduit, will retry", logger.Error(err))
+
+			timer := time.NewTimer(5 * time.Second)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return
+			case <-timer.C:
+			}
+
+			continue
+		}
+
+		break
+	}
+
+	c.startWebSocket(ctx)
+}
+
+func (c *Manager) createConduit(ctx context.Context) error {
 	conduit, err := c.ensureConduit(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to ensure conduit: %w", err)
@@ -72,7 +97,7 @@ func (c *Manager) createConduit() error {
 
 func (c *Manager) ensureConduit(ctx context.Context) (*conduitsResponseConduit, error) {
 	mu := c.redSync.NewMutex("eventsub:conduits")
-	err := mu.Lock()
+	err := mu.LockContext(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to lock conduits mutex: %w", err)
 	}
@@ -216,9 +241,9 @@ func (c *Manager) twitchCreateConduit(ctx context.Context) (*conduitsResponseCon
 
 func (c *Manager) twitchUpdateConduitShard(ctx context.Context) error {
 	mu := c.redSync.NewMutex("eventsub:shard:update")
-	err := mu.Lock()
+	err := mu.LockContext(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to lock conduits mutex: %w", err)
+		return fmt.Errorf("failed to lock shard update mutex: %w", err)
 	}
 	defer mu.Unlock()
 

--- a/apps/eventsub/internal/manager/websocket.go
+++ b/apps/eventsub/internal/manager/websocket.go
@@ -12,8 +12,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-func (c *Manager) startWebSocket() {
-	wsCtx := context.TODO()
+func (c *Manager) startWebSocket(ctx context.Context) {
 	wsOptions := append([]eventsub.WebsocketOption{eventsub.WebsocketWithKeepalive(30)}, c.wsOpts...)
 	ws := c.eventsub.Websocket(wsOptions...)
 
@@ -93,7 +92,15 @@ func (c *Manager) startWebSocket() {
 	ws.OnChannelModerateV2(wrapWsEventsubHandlerWithCtx(c.handler.HandleChannelModerateV2))
 
 	for {
-		if err := ws.Connect(wsCtx); err != nil {
+		if ctx.Err() != nil {
+			return
+		}
+
+		if err := ws.Connect(ctx); err != nil {
+			if ctx.Err() != nil {
+				return
+			}
+
 			c.logger.Error("websocket connection failed", logger.Error(err))
 		}
 
@@ -101,7 +108,11 @@ func (c *Manager) startWebSocket() {
 			c.logger.Warn("websocket disconnection failed", logger.Error(err))
 		}
 
-		time.Sleep(1 * time.Second)
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(1 * time.Second):
+		}
 	}
 }
 


### PR DESCRIPTION
## Problem

Eventsub replicas crash-looped at startup:

```
OnStart hook failed ... error="failed to ensure conduit: failed to lock conduits mutex: lock already taken, locked nodes: [0]"
Start failed ... error="context deadline exceeded"
```

Root causes:

- `OnStart` synchronously called `createConduit()`, which acquires the redsync `eventsub:conduits` mutex. When 3 replicas start simultaneously, the losers got `lock already taken`, fx rolled back the start, the container restarted, and the race repeated.
- `createConduit` ran on `context.TODO()` with no deadline, so the fx start phase eventually died with `context deadline exceeded`.
- There was no `OnStop` hook; the websocket reconnect loop lived forever on `context.TODO()`.

## Changes

- **`manager.go`** — `OnStart` returns immediately, spawning a background worker on a service-owned context (`context.WithCancel(context.Background())`). Added `OnStop` that cancels the worker and waits for it within the fx stop deadline.
- **`on_start.go`** — new `runStartup(ctx)`: ensure-conduit retry loop (logs the error, retries every 5s, cancellable); the websocket starts only after a successful ensure, preserving the `currentConduit` invariant for `twitchUpdateConduitShard`. `createConduit` now takes a context; redsync mutexes use `LockContext(ctx)` so lock acquisition is cancellable. Also fixed the misleading error message on the shard-update mutex.
- **`websocket.go`** — `startWebSocket(ctx)` exits on context cancellation instead of looping forever on `context.TODO()`.

## Behavior

Instead of a crash-loop, replicas that lose the lock race now log `failed to ensure conduit, will retry` and keep retrying in the background while the app stays alive.

## Verification

- `go build ./...` — success
- `go vet ./internal/manager/` — clean
- `go test ./internal/manager/` — 18 passed