### PR TITLE
ci(docker): detect changes for web and migrations jobs

### DIFF
--- a/.github/workflows/dockerv3.yml
+++ b/.github/workflows/dockerv3.yml
@@ -64,6 +64,7 @@ jobs:
     outputs:
       affected: ${{ steps.affected.outputs.apps }}
       affected_services: ${{ steps.affected.outputs.services }}
+      migrations_affected: ${{ steps.affected.outputs.migrations_affected }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -112,17 +113,32 @@ jobs:
           echo "$apps" >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
 
-          # Services for deploy webhook: affected apps + migrations
-          if [ "$apps" = "null" ] || [ "$apps" = "[]" ]; then
-            echo 'services<<EOF' >> "$GITHUB_OUTPUT"
-            echo '["migrations"]' >> "$GITHUB_OUTPUT"
-            echo 'EOF' >> "$GITHUB_OUTPUT"
+          # Migrations image lives outside the apps dependency graph, detect it by paths.
+          if [ "${{ github.event.inputs.skip-change-detect }}" = "true" ]; then
+            migrations_affected="true"
+          elif echo "${{ steps.changed.outputs.files }}" | tr ',' '\n' | grep -qE '^(libs/migrations/|cli/|\.github/workflows/dockerv3\.yml$)'; then
+            migrations_affected="true"
           else
-            services=$(echo "$apps" | sed 's/^\[/["migrations",/')
-            echo "services<<EOF" >> "$GITHUB_OUTPUT"
-            echo "$services" >> "$GITHUB_OUTPUT"
-            echo "EOF" >> "$GITHUB_OUTPUT"
+            migrations_affected="false"
           fi
+          echo "migrations_affected=${migrations_affected}" >> "$GITHUB_OUTPUT"
+
+          # Services for deploy webhook: affected apps + migrations (only when its image is rebuilt)
+          if [ "$apps" = "null" ] || [ "$apps" = "[]" ]; then
+            if [ "$migrations_affected" = "true" ]; then
+              services='["migrations"]'
+            else
+              services='[]'
+            fi
+          elif [ "$migrations_affected" = "true" ]; then
+            services=$(echo "$apps" | sed 's/^\[/["migrations",/')
+          else
+            services="$apps"
+          fi
+
+          echo "services<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$services" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
 
   build-matrix:
     needs:
@@ -273,31 +289,24 @@ jobs:
             registry.twir.app/twirapp/${{ env.app }}:latest
 
   migrations:
-    needs: release-meta
+    needs:
+      - release-meta
+      - detect-affected
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - name: Get changed files
-        if: needs.release-meta.outputs.is_release != 'true'
-        id: changed-files
-        uses: tj-actions/changed-files@v47
-        with:
-          files: |
-            libs/migrations/**
-            cli/**
-            cli/Dockerfile
-            .github/workflows/dockerv3.yml
       - name: Set up Docker Buildx
+        if: needs.detect-affected.outputs.migrations_affected == 'true'
         uses: docker/setup-buildx-action@v3
       - name: Login to Twir registry
-        if: needs.release-meta.outputs.is_release == 'true' || steps.changed-files.outputs.any_changed == 'true' || github.event.inputs.skip-change-detect == 'true'
+        if: needs.detect-affected.outputs.migrations_affected == 'true'
         uses: docker/login-action@v3
         with:
           registry: registry.twir.app
           username: ${{ secrets.DOCKER_TWIR_LOGIN }}
           password: ${{ secrets.DOCKER_TWIR_PASSWORD }}
       - name: Build docker image
-        if: needs.release-meta.outputs.is_release == 'true' || steps.changed-files.outputs.any_changed == 'true' || github.event.inputs.skip-change-detect == 'true'
+        if: needs.detect-affected.outputs.migrations_affected == 'true'
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -308,35 +317,24 @@ jobs:
             registry.twir.app/twirapp/migrations:latest
 
   web:
-    needs: release-meta
+    needs:
+      - release-meta
+      - detect-affected
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - name: Get changed files
-        if: needs.release-meta.outputs.is_release != 'true'
-        id: changed-files
-        uses: tj-actions/changed-files@v47
-        with:
-          files: |
-            web/**
-            libs/**
-            cli/**
-            cli/Dockerfile
-            .bun-version
-            bun.lock
-            package.json
-            .github/workflows/dockerv3.yml
       - name: Set up Docker Buildx
+        if: contains(fromJSON(needs.detect-affected.outputs.affected), 'web')
         uses: docker/setup-buildx-action@v3
       - name: Login to Twir registry
-        if: needs.release-meta.outputs.is_release == 'true' || steps.changed-files.outputs.any_changed == 'true' || github.event.inputs.skip-change-detect == 'true'
+        if: contains(fromJSON(needs.detect-affected.outputs.affected), 'web')
         uses: docker/login-action@v3
         with:
           registry: registry.twir.app
           username: ${{ secrets.DOCKER_TWIR_LOGIN }}
           password: ${{ secrets.DOCKER_TWIR_PASSWORD }}
       - name: Build docker image
-        if: needs.release-meta.outputs.is_release == 'true' || steps.changed-files.outputs.any_changed == 'true' || github.event.inputs.skip-change-detect == 'true'
+        if: contains(fromJSON(needs.detect-affected.outputs.affected), 'web')
         uses: docker/build-push-action@v6
         with:
           context: .


### PR DESCRIPTION
## Problem

`web` and `migrations` jobs rebuilt on **every release**: their `tj-actions/changed-files` steps were skipped on tag pushes (`if: is_release != 'true'`), and the build steps had `is_release == 'true'` as an always-true condition. Since the pipeline runs on tags, change detection effectively never worked for these two images.

## Solution

Reuse the existing `detect-affected` job, which already knows how to diff against the previous release tag:

- **web** — builds when the CLI `affected` graph contains `web` (covers `web/**`, root files like `bun.lock`/`package.json`/workflow, and — tighter than before — only the `@twir/*` libs web actually depends on, instead of all of `libs/**` and `cli/**`).
- **migrations** — not part of the apps dependency graph, so `detect-affected` now also greps the changed file list for `libs/migrations/`, `cli/`, and the workflow file, and exposes a `migrations_affected` output.
- **deploy webhook** — `migrations` is now included in the `services` payload only when its image was actually rebuilt, so the deploy receiver never tries to pull a release tag that doesn't exist. `web` was already flowing through the affected apps list.

`skip-change-detect: true` on manual dispatch still forces everything to build, as before.

## Verification

- YAML parses cleanly.
- Shell logic of the new services/migrations computation simulated locally across 7 scenarios (migrations-only change, app change, web change, unrelated change, force build, workflow change) — all produce the expected services payload.
- `go run ./cli/main.go affected` confirmed: `web/**` → `["web"]`, `bun.lock` → all apps incl. `web`, `libs/api` → `["overlays","web"]`.

## Note

`deploy-receiver` has the same always-build-on-release pattern; left untouched to keep the diff scoped — easy follow-up if wanted.