### PR TITLE
feat(eventsub): optional proxy for VK Video Live Centrifugo

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,6 +66,8 @@ VK_VIDEO_WEBHOOK_SECRET=
 VK_VIDEO_API_BASE_URL=https://api.live.vkvideo.ru
 VK_VIDEO_AUTH_BASE_URL=https://auth.live.vkvideo.ru
 VK_VIDEO_DEVAPI_BASE_URL=https://apidev.live.vkvideo.ru
+# Optional HTTP/SOCKS5 proxy for the VK Video Live Centrifugo (pubsub) WebSocket connection.
+VK_PROXY_URL=
 
 # Google Cloud OAuth client with YouTube Data API v3 enabled, disabled by default.
 # Redirect URIs: <SITE_BASE_URL>/login/youtube and <SITE_BASE_URL>/api/auth/youtube/bot-callback

--- a/apps/eventsub/app/app.go
+++ b/apps/eventsub/app/app.go
@@ -167,15 +167,16 @@ var App = fx.Options(
 					return nil, fmt.Errorf("create VK Video WebSocket token client: %w", err)
 				}
 
-				return vkvideo.New(vkvideo.Opts{
-					Logger:               logger,
-					Redis:                redisClient,
-					Bus:                  bus,
-					UserCreator:          userCreator,
-					WebSocketTokenClient: webSocketTokenClient,
-					ChannelsRepo:         channelsRepo,
-					Lc:                   lc,
-				})
+			return vkvideo.New(vkvideo.Opts{
+				Logger:               logger,
+				Redis:                redisClient,
+				Bus:                  bus,
+				UserCreator:          userCreator,
+				WebSocketTokenClient: webSocketTokenClient,
+				ChannelsRepo:         channelsRepo,
+				Lc:                   lc,
+				ProxyUrl:             config.VkProxyUrl,
+			})
 			})
 		},
 		kick.NewHandlers,

--- a/apps/eventsub/internal/vkvideo/realtime_client.go
+++ b/apps/eventsub/internal/vkvideo/realtime_client.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/http"
+	"net/url"
 
 	centrifuge "github.com/centrifugal/centrifuge-go"
 	"github.com/google/uuid"
@@ -30,6 +32,9 @@ type RealtimeClientConfig struct {
 	BindingID     uuid.UUID
 	Logger        *slog.Logger
 	Tokens        TokenCallbacks
+	// ProxyUrl is an optional proxy URL for the Centrifugo WebSocket
+	// connection. When empty, http.ProxyFromEnvironment behavior is used.
+	ProxyUrl string
 }
 
 type RealtimeClient struct {
@@ -64,6 +69,15 @@ func newRealtimeClient(config RealtimeClientConfig, endpoint string) (*RealtimeC
 		return nil, fmt.Errorf("create publication session: %w", err)
 	}
 
+	var proxy func(*http.Request) (*url.URL, error)
+	if config.ProxyUrl != "" {
+		proxyURL, err := url.Parse(config.ProxyUrl)
+		if err != nil {
+			return nil, fmt.Errorf("parse proxy url: %w: %w", err, ErrInvalidRealtimeClientConfig)
+		}
+		proxy = http.ProxyURL(proxyURL)
+	}
+
 	realtimeClient := &RealtimeClient{
 		session:   session,
 		channel:   config.Channel,
@@ -72,6 +86,7 @@ func newRealtimeClient(config RealtimeClientConfig, endpoint string) (*RealtimeC
 		logger:    config.Logger,
 	}
 	realtimeClient.client = centrifuge.NewJsonClient(endpoint, centrifuge.Config{
+		Proxy: proxy,
 		GetToken: func(centrifuge.ConnectionTokenEvent) (string, error) {
 			return realtimeClient.tokens.Connection(realtimeClient.tokens.Context)
 		},

--- a/apps/eventsub/internal/vkvideo/realtime_client_test.go
+++ b/apps/eventsub/internal/vkvideo/realtime_client_test.go
@@ -25,6 +25,63 @@ type lifecycleLogEntry struct {
 	Error         string `json:"error"`
 }
 
+func TestNewRealtimeClientRejectsInvalidProxyUrl(t *testing.T) {
+	// Given
+	config := RealtimeClientConfig{
+		Channel:       "channel-chat:123",
+		QueueCapacity: 1,
+		ProxyUrl:      "http://proxy.invalid:port",
+		Tokens: TokenCallbacks{
+			Context: context.Background(),
+			Connection: func(context.Context) (string, error) {
+				return "connection-token", nil
+			},
+			Subscription: func(context.Context, string) (string, error) {
+				return "subscription-token", nil
+			},
+		},
+	}
+
+	// When
+	client, err := newRealtimeClient(config, "ws://localhost/connection/websocket")
+
+	// Then
+	if client != nil {
+		client.Close()
+		t.Fatal("expected nil client for invalid proxy url")
+	}
+	if !errors.Is(err, ErrInvalidRealtimeClientConfig) {
+		t.Fatalf("expected ErrInvalidRealtimeClientConfig, got %v", err)
+	}
+}
+
+func TestNewRealtimeClientAcceptsProxyUrl(t *testing.T) {
+	// Given
+	config := RealtimeClientConfig{
+		Channel:       "channel-chat:123",
+		QueueCapacity: 1,
+		ProxyUrl:      "socks5://user:pass@127.0.0.1:1080",
+		Tokens: TokenCallbacks{
+			Context: context.Background(),
+			Connection: func(context.Context) (string, error) {
+				return "connection-token", nil
+			},
+			Subscription: func(context.Context, string) (string, error) {
+				return "subscription-token", nil
+			},
+		},
+	}
+
+	// When
+	client, err := newRealtimeClient(config, "ws://localhost/connection/websocket")
+
+	// Then
+	if err != nil {
+		t.Fatalf("create realtime client with proxy url: %v", err)
+	}
+	client.Close()
+}
+
 func TestRealtimeClient_handlePublicationLogsReceiptMetadata(t *testing.T) {
 	// Given
 	var logBuffer bytes.Buffer

--- a/apps/eventsub/internal/vkvideo/subscription.go
+++ b/apps/eventsub/internal/vkvideo/subscription.go
@@ -27,6 +27,7 @@ func (t *Transport) startBinding(
 		QueueCapacity: 128,
 		BindingID:     binding.ID,
 		Logger:        t.logger,
+		ProxyUrl:      t.proxyUrl,
 		Tokens: TokenCallbacks{
 			Context: lease.Context(),
 			Connection: func(ctx context.Context) (string, error) {

--- a/apps/eventsub/internal/vkvideo/transport.go
+++ b/apps/eventsub/internal/vkvideo/transport.go
@@ -36,6 +36,7 @@ type Opts struct {
 	WebSocketTokenClient *vk.WebSocketTokenClient
 	ChannelsRepo         channels.Repository
 	Lc                   fx.Lifecycle
+	ProxyUrl             string
 }
 
 type Transport struct {
@@ -48,6 +49,7 @@ type Transport struct {
 	deduplicator     messageDeduplicator
 	newConnection    realtimeConnectionFactory
 	databaseBindings bindingsProvider
+	proxyUrl         string
 
 	mu               sync.Mutex
 	bindings         map[uuid.UUID]*activeBinding
@@ -64,6 +66,7 @@ type transportDependencies struct {
 	deduplicator     messageDeduplicator
 	newConnection    realtimeConnectionFactory
 	databaseBindings bindingsProvider
+	proxyUrl         string
 }
 
 func New(opts Opts) (*Transport, error) {
@@ -86,6 +89,7 @@ func New(opts Opts) (*Transport, error) {
 		deduplicator:     redisDeduplicator{redis: opts.Redis},
 		newConnection:    newCentrifugoConnection,
 		databaseBindings: newDatabaseBindingsProvider(opts.ChannelsRepo),
+		proxyUrl:         opts.ProxyUrl,
 	})
 	reconcileCtx, stopReconcile := context.WithCancel(context.Background())
 	go transport.reconcileLoop(reconcileCtx)
@@ -112,6 +116,7 @@ func newTransport(deps transportDependencies) *Transport {
 		deduplicator:     deps.deduplicator,
 		newConnection:    deps.newConnection,
 		databaseBindings: deps.databaseBindings,
+		proxyUrl:         deps.proxyUrl,
 		bindings:         make(map[uuid.UUID]*activeBinding),
 		contentionLogged: make(map[uuid.UUID]bool),
 	}

--- a/libs/config/config.go
+++ b/libs/config/config.go
@@ -108,6 +108,11 @@ type Config struct {
 	VKVideoAuthBaseURL   string `required:"false" default:"https://auth.live.vkvideo.ru" envconfig:"VK_VIDEO_AUTH_BASE_URL"`
 	VKVideoDevAPIBaseURL string `required:"false" default:"https://apidev.live.vkvideo.ru" envconfig:"VK_VIDEO_DEVAPI_BASE_URL"`
 
+	// VkProxyUrl is an optional HTTP/SOCKS5 proxy URL used for the VK Video
+	// Live Centrifugo (pubsub) WebSocket connection, e.g. "http://host:port"
+	// or "socks5://user:pass@host:port".
+	VkProxyUrl string `required:"false" envconfig:"VK_PROXY_URL"`
+
 	YouTubeClientID     string `required:"false" envconfig:"YOUTUBE_CLIENT_ID"`
 	YouTubeClientSecret string `required:"false" envconfig:"YOUTUBE_CLIENT_SECRET"`
 


### PR DESCRIPTION
## Summary

Adds an optional `VkProxyUrl` config (`VK_PROXY_URL` env). When set, the eventsub VK Video Live realtime client dials the Centrifugo pubsub WebSocket (`pubsub-dev.live.vkvideo.ru`) through the given HTTP/SOCKS5 proxy; when empty, the previous `http.ProxyFromEnvironment` behavior is preserved.

## Changes

- `libs/config`: new optional `VkProxyUrl` field (`VK_PROXY_URL`) + `.env.example` entry.
- `apps/eventsub`: `RealtimeClientConfig.ProxyUrl` parsed in `newRealtimeClient` and passed to `centrifuge.Config.Proxy`; invalid URLs fail fast with `ErrInvalidRealtimeClientConfig`.
- Proxy URL plumbed from app config through `vkvideo.Opts` → `Transport` → `RealtimeClientConfig`.
- Tests: accept valid proxy URL, reject invalid proxy URL.

## Verification

- `go build` / `go vet` clean for `apps/eventsub` and `libs/config`.
- `go test ./internal/vkvideo/...`: 36 passed.
- `go test` in `libs/config`: 3 passed.