### PR TITLE
feat(stack): add Uptrace observability

### DIFF
--- a/configs/uptrace/README.md
+++ b/configs/uptrace/README.md
@@ -1,0 +1,66 @@
+# Uptrace on the Twir Docker Swarm
+
+The stack runs the Uptrace UI/API on application nodes and keeps its dedicated ClickHouse,
+PostgreSQL, and Redis services on the node labeled `databases=true`. `node-exporter` and cAdvisor
+run globally; one OpenTelemetry Collector discovers and scrapes every exporter task.
+
+## One-time preparation
+
+Ensure the database node has the label used by the stack:
+
+```sh
+docker node update --label-add databases=true DATABASE_NODE
+```
+
+Create the external Docker secrets. Secret values must be single-line strings; hex is recommended
+for generated infrastructure secrets. Preserve the project token from the existing Uptrace server
+so existing SDK configuration keeps working:
+
+```sh
+project_token="$(ssh root@169.58.78.216 "sed -n 's/^PROJECT_TOKEN=//p' /opt/uptrace/.credentials")"
+printf 'http://%s@uptrace:4317/1' "$project_token" | docker secret create uptrace_dsn -
+unset project_token
+
+openssl rand -hex 32 | docker secret create uptrace_service_secret -
+openssl rand -hex 32 | docker secret create uptrace_clickhouse_password -
+openssl rand -hex 32 | docker secret create uptrace_postgres_password -
+
+read -r -s -p 'Uptrace admin password: ' uptrace_admin_password
+printf '%s' "$uptrace_admin_password" | docker secret create uptrace_admin_password -
+unset uptrace_admin_password
+```
+
+The internal DSN above is intentionally used by the Collector. Applications inside the Swarm can
+send unauthenticated OTLP to `otel-collector:4317`; the Collector adds the Uptrace DSN when it
+forwards telemetry. Set the application configuration to:
+
+```text
+OTEL_ENDPOINT=otel-collector:4317
+OTEL_INSECURE=true
+OTEL_HEADERS=
+```
+
+## Deploy
+
+```sh
+docker stack deploy --with-registry-auth -c docker-compose.stack.yml twir
+```
+
+Uptrace is routed through Traefik at `https://uptrace.twir.app`. The separate Grafana service is no
+longer needed: Uptrace provides the UI and is Prometheus/Tempo compatible if Grafana is added again
+later. If an old Grafana service still belongs to the `twir` stack, verify its name and remove it
+after Uptrace is healthy, or use `docker stack deploy --prune` during the planned cutover.
+
+## Verify
+
+```sh
+docker stack services twir
+docker service logs twir_uptrace --since 10m
+docker service logs twir_otel-collector --since 10m
+docker service ps twir_node-exporter
+docker service ps twir_cadvisor
+```
+
+The `uptrace-clickhouse-ttl` one-shot service waits for Uptrace migrations and then applies the same
+seven-day telemetry retention policy used by the standalone server. The ClickHouse config also
+disables high-volume system log tables and retains `system.query_log` for one day.

--- a/configs/uptrace/apply-ttl.sql
+++ b/configs/uptrace/apply-ttl.sql
@@ -1,0 +1,25 @@
+-- Keep all Uptrace telemetry for seven days. Safe to re-apply after migrations.
+ALTER TABLE spans_index         MODIFY TTL toDate(time) + INTERVAL 7 DAY;
+ALTER TABLE spans_data          MODIFY TTL toDate(time) + INTERVAL 7 DAY;
+ALTER TABLE span_links          MODIFY TTL toDate(time) + INTERVAL 7 DAY;
+ALTER TABLE events_index        MODIFY TTL toDate(time) + INTERVAL 7 DAY;
+ALTER TABLE events_data         MODIFY TTL toDate(time) + INTERVAL 7 DAY;
+ALTER TABLE logs_index          MODIFY TTL toDate(time) + INTERVAL 7 DAY;
+ALTER TABLE logs_data           MODIFY TTL toDate(time) + INTERVAL 7 DAY;
+ALTER TABLE found_spans         MODIFY TTL toDate(time) + INTERVAL 7 DAY;
+ALTER TABLE span_group_hours    MODIFY TTL toDate(time) + INTERVAL 7 DAY;
+ALTER TABLE span_group_minutes  MODIFY TTL toDate(time) + INTERVAL 7 DAY;
+ALTER TABLE log_group_hours     MODIFY TTL toDate(time) + INTERVAL 7 DAY;
+ALTER TABLE log_group_minutes   MODIFY TTL toDate(time) + INTERVAL 7 DAY;
+ALTER TABLE event_group_hours   MODIFY TTL toDate(time) + INTERVAL 7 DAY;
+ALTER TABLE event_group_minutes MODIFY TTL toDate(time) + INTERVAL 7 DAY;
+ALTER TABLE timeseries          MODIFY TTL toDate(time) + INTERVAL 7 DAY;
+ALTER TABLE datapoints          MODIFY TTL toDate(time) + INTERVAL 7 DAY;
+ALTER TABLE preagg_datapoints   MODIFY TTL toDate(time) + INTERVAL 7 DAY;
+ALTER TABLE service_graph_edges MODIFY TTL toDate(time) + INTERVAL 7 DAY;
+ALTER TABLE span_group_hours    MODIFY SETTING ttl_only_drop_parts = 1;
+ALTER TABLE span_group_minutes  MODIFY SETTING ttl_only_drop_parts = 1;
+ALTER TABLE log_group_hours     MODIFY SETTING ttl_only_drop_parts = 1;
+ALTER TABLE log_group_minutes   MODIFY SETTING ttl_only_drop_parts = 1;
+ALTER TABLE event_group_hours   MODIFY SETTING ttl_only_drop_parts = 1;
+ALTER TABLE event_group_minutes MODIFY SETTING ttl_only_drop_parts = 1;

--- a/configs/uptrace/clickhouse/00-listen.xml
+++ b/configs/uptrace/clickhouse/00-listen.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<clickhouse>
+	<listen_host>::</listen_host>
+	<listen_host>0.0.0.0</listen_host>
+	<listen_try>1</listen_try>
+</clickhouse>

--- a/configs/uptrace/clickhouse/90-disable-system-logs.xml
+++ b/configs/uptrace/clickhouse/90-disable-system-logs.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<clickhouse>
+	<!-- Keep ClickHouse system tables from consuming observability storage. -->
+	<asynchronous_metric_log remove="1"/>
+	<metric_log remove="1"/>
+	<query_thread_log remove="1"/>
+	<query_views_log remove="1"/>
+	<part_log remove="1"/>
+	<session_log remove="1"/>
+	<text_log remove="1"/>
+	<trace_log remove="1"/>
+	<crash_log remove="1"/>
+	<opentelemetry_span_log remove="1"/>
+	<zookeeper_log remove="1"/>
+	<processors_profile_log remove="1"/>
+	<latency_log remove="1"/>
+
+	<query_log replace="1">
+		<database>system</database>
+		<table>query_log</table>
+		<engine>ENGINE = MergeTree PARTITION BY (event_date) ORDER BY (event_time) TTL event_date + INTERVAL 1 DAY DELETE</engine>
+		<flush_interval_milliseconds>7500</flush_interval_milliseconds>
+	</query_log>
+
+	<logger>
+		<level>warning</level>
+	</logger>
+
+	<profiles>
+		<default>
+			<log_queries>0</log_queries>
+			<log_query_threads>0</log_query_threads>
+		</default>
+	</profiles>
+</clickhouse>

--- a/configs/uptrace/entrypoint.sh
+++ b/configs/uptrace/entrypoint.sh
@@ -1,0 +1,56 @@
+#!/bin/sh
+set -eu
+
+read_secret() {
+	tr -d '\r\n' < "/run/secrets/$1"
+}
+
+escape_yaml_sed() {
+	printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' -e 's/[\\|&]/\\&/g'
+}
+
+uptrace_dsn="$(read_secret uptrace_dsn)"
+case "$uptrace_dsn" in
+	*://*@*/[0-9]*) ;;
+	*)
+		echo "uptrace_dsn must look like http://TOKEN@uptrace:4317/1" >&2
+		exit 1
+		;;
+esac
+
+project_token="${uptrace_dsn#*://}"
+project_token="${project_token%%@*}"
+service_secret="$(read_secret uptrace_service_secret)"
+admin_password="$(read_secret uptrace_admin_password)"
+clickhouse_password="$(read_secret uptrace_clickhouse_password)"
+postgres_password="$(read_secret uptrace_postgres_password)"
+
+sed \
+	-e "s|__UPTRACE_PROJECT_TOKEN__|$(escape_yaml_sed "$project_token")|g" \
+	-e "s|__UPTRACE_SERVICE_SECRET__|$(escape_yaml_sed "$service_secret")|g" \
+	-e "s|__UPTRACE_ADMIN_PASSWORD__|$(escape_yaml_sed "$admin_password")|g" \
+	-e "s|__UPTRACE_CLICKHOUSE_PASSWORD__|$(escape_yaml_sed "$clickhouse_password")|g" \
+	-e "s|__UPTRACE_POSTGRES_PASSWORD__|$(escape_yaml_sed "$postgres_password")|g" \
+	/etc/uptrace/config.yml.tmpl > /tmp/uptrace.yml
+chmod 600 /tmp/uptrace.yml
+
+retry() {
+	operation="$1"
+	shift
+	attempt=1
+	while ! "$@"; do
+		if [ "$attempt" -ge 60 ]; then
+			echo "$operation failed after $attempt attempts" >&2
+			exit 1
+		fi
+		attempt=$((attempt + 1))
+		sleep 5
+	done
+}
+
+retry "PostgreSQL initialization" /uptrace --config=/tmp/uptrace.yml pg init
+/uptrace --config=/tmp/uptrace.yml pg migrate
+retry "ClickHouse initialization" /uptrace --config=/tmp/uptrace.yml ch init
+/uptrace --config=/tmp/uptrace.yml ch migrate
+/uptrace --config=/tmp/uptrace.yml db seed
+exec /uptrace --config=/tmp/uptrace.yml serve

--- a/configs/uptrace/otel-collector.yml
+++ b/configs/uptrace/otel-collector.yml
@@ -1,0 +1,61 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+  prometheus:
+    config:
+      global:
+        scrape_interval: 15s
+        scrape_timeout: 10s
+      scrape_configs:
+        - job_name: node-exporter
+          dns_sd_configs:
+            - names: [tasks.node-exporter]
+              type: A
+              port: 9100
+        - job_name: cadvisor
+          dns_sd_configs:
+            - names: [tasks.cadvisor]
+              type: A
+              port: 8080
+
+processors:
+  memory_limiter:
+    check_interval: 5s
+    limit_mib: 384
+    spike_limit_mib: 96
+  batch:
+    timeout: 5s
+    send_batch_size: 4096
+
+exporters:
+  otlp/uptrace:
+    endpoint: uptrace:4317
+    tls:
+      insecure: true
+    headers:
+      uptrace-dsn: ${file:/run/secrets/uptrace_dsn}
+
+extensions:
+  health_check:
+    endpoint: 0.0.0.0:13133
+
+service:
+  extensions: [health_check]
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [otlp/uptrace]
+    metrics:
+      receivers: [otlp, prometheus]
+      processors: [memory_limiter, batch]
+      exporters: [otlp/uptrace]
+    logs:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [otlp/uptrace]

--- a/configs/uptrace/uptrace.yml
+++ b/configs/uptrace/uptrace.yml
@@ -1,0 +1,97 @@
+service:
+  env: production
+  secret: "__UPTRACE_SERVICE_SECRET__"
+
+site:
+  url: https://uptrace.twir.app
+  ingest_url: https://uptrace.twir.app
+
+listen:
+  http:
+    addr: :80
+  grpc:
+    addr: :4317
+
+seed_data:
+  update: true
+  delete: true
+  users:
+    - key: twir_admin
+      name: Twir Admin
+      email: uptrace@twir.app
+      password: "__UPTRACE_ADMIN_PASSWORD__"
+      email_confirmed: true
+  orgs:
+    - key: twir
+      name: Twir
+  org_users:
+    - key: twir_admin_owner
+      org_key: twir
+      user_key: twir_admin
+      role: owner
+  projects:
+    - key: twir
+      name: Twir
+      org_key: twir
+  project_tokens:
+    - key: twir_token
+      project_key: twir
+      token: "__UPTRACE_PROJECT_TOKEN__"
+  project_users:
+    - key: twir_admin_project
+      project_key: twir
+      org_user_key: twir_admin_owner
+      perm_level: admin
+
+ch_cluster:
+  cluster: uptrace1
+  replicated: false
+  distributed: false
+  shards:
+    - replicas:
+        - addr: uptrace-clickhouse:9000
+          database: uptrace
+          user: uptrace
+          password: "__UPTRACE_CLICKHOUSE_PASSWORD__"
+          dial_timeout: 3s
+          write_timeout: 5s
+          max_retries: 3
+          max_execution_time: 15s
+
+pg:
+  addr: uptrace-postgres:5432
+  user: uptrace
+  password: "__UPTRACE_POSTGRES_PASSWORD__"
+  database: uptrace
+
+ch_schema:
+  compression: ZSTD(1)
+  spans_index: { storage_policy: default }
+  spans_data: { storage_policy: default }
+  span_links: { storage_policy: default }
+  logs_index: { storage_policy: default }
+  logs_data: { storage_policy: default }
+  events_index: { storage_policy: default }
+  events_data: { storage_policy: default }
+  timeseries: { storage_policy: default }
+  datapoints: { storage_policy: default }
+
+redis_cache:
+  addrs:
+    1: uptrace-redis:6379
+  username: ""
+  password: ""
+  db: 0
+
+certmagic:
+  enabled: false
+
+mailer:
+  smtp:
+    enabled: false
+
+self_monitoring:
+  disabled: true
+
+logging:
+  level: INFO

--- a/docker-compose.stack.yml
+++ b/docker-compose.stack.yml
@@ -116,22 +116,129 @@ services:
         - "traefik.http.routers.twir-nats.service=twir-nats"
         - "traefik.http.services.twir-nats.loadbalancer.server.port=8222"
 
-  #  otel-collector:
-  #    image: otel/opentelemetry-collector-contrib:0.121.0
-  #    user: "0:0"
-  #    volumes:
-  #      - ./configs/otel/otel-collector.yaml:/etc/otelcol-contrib/config.yaml
-  #      - /var/run/docker.sock:/var/run/docker.sock:ro
-  #      - /var/lib/docker/containers:/var/lib/docker/containers:ro
-  #    networks:
-  #      - twir
-  #    deploy:
-  #      mode: global
-  #      restart_policy:
-  #        condition: any
-  #        delay: 3s
-  #        max_attempts: 30
-  #      endpoint_mode: dnsrr
+  uptrace:
+    image: uptrace/uptrace:2.1.0-beta.5
+    entrypoint: ["/bin/sh", "/etc/uptrace/entrypoint.sh"]
+    configs:
+      - source: uptrace_config
+        target: /etc/uptrace/config.yml.tmpl
+      - source: uptrace_entrypoint
+        target: /etc/uptrace/entrypoint.sh
+    secrets:
+      - uptrace_dsn
+      - uptrace_service_secret
+      - uptrace_admin_password
+      - uptrace_clickhouse_password
+      - uptrace_postgres_password
+    networks:
+      - twir
+      - traefik-public
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost/api/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 90s
+    deploy:
+      replicas: 1
+      restart_policy:
+        condition: on-failure
+        delay: 5s
+        max_attempts: 30
+      placement:
+        constraints:
+          - node.labels.databases != true
+      labels:
+        - "traefik.enable=true"
+        - "traefik.swarm.network=traefik-public"
+        - "traefik.http.routers.twir-uptrace.rule=Host(`uptrace.twir.app`)"
+        - "traefik.http.routers.twir-uptrace.entrypoints=web"
+        - "traefik.http.routers.twir-uptrace.service=twir-uptrace"
+        - "traefik.http.routers.twir-uptrace.middlewares=gzip,rate-limit"
+        - "traefik.http.services.twir-uptrace.loadbalancer.server.port=80"
+
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:0.157.0
+    command: ["--config=/etc/otelcol-contrib/config.yaml"]
+    configs:
+      - source: uptrace_otel_collector_config
+        target: /etc/otelcol-contrib/config.yaml
+    secrets:
+      - uptrace_dsn
+    networks:
+      - twir
+    deploy:
+      replicas: 1
+      restart_policy:
+        condition: any
+        delay: 5s
+        max_attempts: 30
+      placement:
+        constraints:
+          - node.role == manager
+      resources:
+        limits:
+          memory: 512M
+
+  node-exporter:
+    image: prom/node-exporter:v1.12.1
+    command:
+      - "--path.rootfs=/host"
+      - "--collector.filesystem.mount-points-exclude=^/(dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/.+)($$|/)"
+    pid: host
+    volumes:
+      - type: bind
+        source: /
+        target: /host
+        read_only: true
+        bind:
+          propagation: rslave
+    networks:
+      - twir
+    deploy:
+      mode: global
+      restart_policy:
+        condition: any
+        delay: 5s
+        max_attempts: 30
+      resources:
+        limits:
+          memory: 128M
+
+  cadvisor:
+    image: gcr.io/cadvisor/cadvisor:v0.60.5
+    command:
+      - "--docker_only=true"
+      - "--housekeeping_interval=15s"
+    privileged: true
+    volumes:
+      - type: bind
+        source: /
+        target: /rootfs
+        read_only: true
+      - type: bind
+        source: /var/run
+        target: /var/run
+        read_only: true
+      - type: bind
+        source: /sys
+        target: /sys
+        read_only: true
+      - type: bind
+        source: /var/lib/docker
+        target: /var/lib/docker
+        read_only: true
+    networks:
+      - twir
+    deploy:
+      mode: global
+      restart_policy:
+        condition: any
+        delay: 5s
+        max_attempts: 30
+      resources:
+        limits:
+          memory: 256M
 
   postgres:
     image: postgres:18.1
@@ -240,6 +347,137 @@ services:
       - SYS_NICE
       - NET_ADMIN
       - IPC_LOCK
+
+  uptrace-clickhouse:
+    image: clickhouse/clickhouse-server:26.3
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - 'export CLICKHOUSE_PASSWORD="$$(tr -d ''\r\n'' < /run/secrets/uptrace_clickhouse_password)"; exec /entrypoint.sh'
+    environment:
+      CLICKHOUSE_USER: uptrace
+      CLICKHOUSE_DB: uptrace
+    secrets:
+      - uptrace_clickhouse_password
+    configs:
+      - source: uptrace_clickhouse_listen_config
+        target: /etc/clickhouse-server/config.d/00-listen.xml
+      - source: uptrace_clickhouse_optimization_config
+        target: /etc/clickhouse-server/config.d/90-disable-system-logs.xml
+    volumes:
+      - uptrace-clickhouse-data:/var/lib/clickhouse
+    networks:
+      - twir
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "localhost:8123/ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 20s
+    ulimits:
+      nofile: 262144
+    cap_add:
+      - SYS_NICE
+      - NET_ADMIN
+      - IPC_LOCK
+    deploy:
+      replicas: 1
+      restart_policy:
+        condition: any
+        delay: 5s
+        max_attempts: 30
+      endpoint_mode: dnsrr
+      placement:
+        constraints:
+          - node.labels.databases == true
+      resources:
+        limits:
+          cpus: "2.0"
+          memory: 3G
+
+  uptrace-postgres:
+    image: postgres:17-alpine
+    environment:
+      PGDATA: /var/lib/postgresql/data/pgdata
+      POSTGRES_USER: uptrace
+      POSTGRES_PASSWORD_FILE: /run/secrets/uptrace_postgres_password
+      POSTGRES_DB: uptrace
+    secrets:
+      - uptrace_postgres_password
+    volumes:
+      - uptrace-postgres-data:/var/lib/postgresql/data
+    networks:
+      - twir
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U uptrace -d uptrace"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 20s
+    deploy:
+      replicas: 1
+      restart_policy:
+        condition: any
+        delay: 5s
+        max_attempts: 30
+      endpoint_mode: dnsrr
+      placement:
+        constraints:
+          - node.labels.databases == true
+
+  uptrace-redis:
+    image: redis:7-alpine
+    command: redis-server --save "" --appendonly no --loglevel warning
+    networks:
+      - twir
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 10s
+    deploy:
+      replicas: 1
+      restart_policy:
+        condition: any
+        delay: 5s
+        max_attempts: 30
+      endpoint_mode: dnsrr
+      placement:
+        constraints:
+          - node.labels.databases == true
+
+  uptrace-clickhouse-ttl:
+    image: clickhouse/clickhouse-server:26.3
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        password="$$(tr -d '\r\n' < /run/secrets/uptrace_clickhouse_password)"
+        attempt=1
+        until [ "$$(clickhouse-client --host uptrace-clickhouse --user uptrace --password "$$password" --database uptrace --query 'EXISTS TABLE spans_index' 2>/dev/null)" = "1" ]; do
+          if [ "$$attempt" -ge 60 ]; then
+            echo "Uptrace schema was not ready after $$attempt attempts" >&2
+            exit 1
+          fi
+          attempt=$$((attempt + 1))
+          sleep 5
+        done
+        exec clickhouse-client --host uptrace-clickhouse --user uptrace --password "$$password" --database uptrace --multiquery < /etc/uptrace/apply-ttl.sql
+    secrets:
+      - uptrace_clickhouse_password
+    configs:
+      - source: uptrace_clickhouse_ttl
+        target: /etc/uptrace/apply-ttl.sql
+    networks:
+      - twir
+    deploy:
+      replicas: 1
+      restart_policy:
+        condition: on-failure
+        delay: 10s
+        max_attempts: 10
+      placement:
+        constraints:
+          - node.labels.databases == true
 
   temporal-postgres:
     image: "bitnamilegacy/postgresql:17"
@@ -960,6 +1198,19 @@ configs:
   clickhouse_config:
     file: ./configs/clickhouse-config.xml
 
+  uptrace_config:
+    file: ./configs/uptrace/uptrace.yml
+  uptrace_entrypoint:
+    file: ./configs/uptrace/entrypoint.sh
+  uptrace_otel_collector_config:
+    file: ./configs/uptrace/otel-collector.yml
+  uptrace_clickhouse_listen_config:
+    file: ./configs/uptrace/clickhouse/00-listen.xml
+  uptrace_clickhouse_optimization_config:
+    file: ./configs/uptrace/clickhouse/90-disable-system-logs.xml
+  uptrace_clickhouse_ttl:
+    file: ./configs/uptrace/apply-ttl.sql
+
   pgdog_users_config:
     file: ./configs/pgdog/users.toml
   pgdog_config:
@@ -973,6 +1224,8 @@ volumes:
   minio-data:
   temporal-postgres-data:
   clickhouse-data:
+  uptrace-clickhouse-data:
+  uptrace-postgres-data:
   dbx-data:
 
 networks:
@@ -994,4 +1247,14 @@ secrets:
   twir_postgres_password:
     external: true
   twir_deploy_webhook_token:
+    external: true
+  uptrace_dsn:
+    external: true
+  uptrace_service_secret:
+    external: true
+  uptrace_admin_password:
+    external: true
+  uptrace_clickhouse_password:
+    external: true
+  uptrace_postgres_password:
     external: true


### PR DESCRIPTION
## Summary

- deploy Uptrace with dedicated ClickHouse, PostgreSQL, and Redis services
- collect Swarm host and container metrics with node-exporter, cAdvisor, and OpenTelemetry Collector
- mirror the standalone ClickHouse optimizations and seven-day telemetry TTL
- keep Uptrace credentials in external Docker Swarm secrets

## Deployment notes

- create the external secrets documented in configs/uptrace/README.md before deployment
- point application OTLP traffic to otel-collector:4317
- the legacy Grafana service is not present in the stack; remove it with a planned prune only after Uptrace is healthy
- existing telemetry data is not migrated from the standalone server

## Validation

- docker compose config --quiet
- docker stack config
- otelcol validate
- Uptrace config validate
- shell syntax and git diff checks