### PR TITLE
feat(stack): connect Grafana to Uptrace

### DIFF
--- a/configs/uptrace/README.md
+++ b/configs/uptrace/README.md
@@ -13,8 +13,8 @@ docker node update --label-add databases=true DATABASE_NODE
 ```
 
 Create the external Docker secrets. Secret values must be single-line strings; hex is recommended
-for generated infrastructure secrets. Preserve the project token from the existing Uptrace server
-so existing SDK configuration keeps working:
+for generated infrastructure secrets. Applications send telemetry through the Collector, so the
+new Uptrace installation uses a new project token:
 
 ```sh
 project_token="$(openssl rand -hex 32)"
@@ -25,9 +25,15 @@ openssl rand -hex 32 | docker secret create uptrace_service_secret -
 openssl rand -hex 32 | docker secret create uptrace_clickhouse_password -
 openssl rand -hex 32 | docker secret create uptrace_postgres_password -
 
-read -r -s -p 'Uptrace admin password: ' uptrace_admin_password
+uptrace_admin_password="$(openssl rand -hex 16)"
+printf 'Save Uptrace admin password: %s\n' "$uptrace_admin_password"
 printf '%s' "$uptrace_admin_password" | docker secret create uptrace_admin_password -
 unset uptrace_admin_password
+
+grafana_admin_password="$(openssl rand -hex 16)"
+printf 'Save Grafana admin password: %s\n' "$grafana_admin_password"
+printf '%s' "$grafana_admin_password" | docker secret create grafana_admin_password -
+unset grafana_admin_password
 ```
 
 The internal DSN above is intentionally used by the Collector. Applications inside the Swarm can
@@ -46,10 +52,9 @@ OTEL_HEADERS=
 docker stack deploy --with-registry-auth -c docker-compose.stack.yml twir
 ```
 
-Uptrace is routed through Traefik at `https://uptrace.twir.app`. The separate Grafana service is no
-longer needed: Uptrace provides the UI and is Prometheus/Tempo compatible if Grafana is added again
-later. If an old Grafana service still belongs to the `twir` stack, verify its name and remove it
-after Uptrace is healthy, or use `docker stack deploy --prune` during the planned cutover.
+Uptrace is routed through Traefik at `https://uptrace.twir.app`. Grafana is available at
+`https://grafana.twir.app` and is provisioned with Uptrace Tempo and Prometheus data sources. It
+extracts the project token from the existing `uptrace_dsn` secret.
 
 ## Verify
 
@@ -57,6 +62,7 @@ after Uptrace is healthy, or use `docker stack deploy --prune` during the planne
 docker stack services twir
 docker service logs twir_uptrace --since 10m
 docker service logs twir_otel-collector --since 10m
+docker service logs twir_grafana --since 10m
 docker service ps twir_node-exporter
 docker service ps twir_cadvisor
 ```

--- a/configs/uptrace/README.md
+++ b/configs/uptrace/README.md
@@ -17,7 +17,7 @@ for generated infrastructure secrets. Preserve the project token from the existi
 so existing SDK configuration keeps working:
 
 ```sh
-project_token="$(ssh root@169.58.78.216 "sed -n 's/^PROJECT_TOKEN=//p' /opt/uptrace/.credentials")"
+project_token="$(openssl rand -hex 32)"
 printf 'http://%s@uptrace:4317/1' "$project_token" | docker secret create uptrace_dsn -
 unset project_token
 

--- a/configs/uptrace/grafana/datasource.yml
+++ b/configs/uptrace/grafana/datasource.yml
@@ -1,0 +1,32 @@
+apiVersion: 1
+
+prune: true
+
+datasources:
+  - name: Uptrace Tempo
+    uid: uptrace-tempo
+    type: tempo
+    access: proxy
+    url: http://uptrace/api/tempo/1
+    editable: false
+    jsonData:
+      httpHeaderName1: Authorization
+      nodeGraph:
+        enabled: true
+      serviceMap:
+        datasourceUid: uptrace-prometheus
+    secureJsonData:
+      httpHeaderValue1: ${UPTRACE_PROJECT_TOKEN}
+
+  - name: Uptrace Prometheus
+    uid: uptrace-prometheus
+    type: prometheus
+    access: proxy
+    url: http://uptrace/api/prometheus/1
+    editable: false
+    isDefault: true
+    jsonData:
+      httpHeaderName1: Authorization
+      httpMethod: POST
+    secureJsonData:
+      httpHeaderValue1: ${UPTRACE_PROJECT_TOKEN}

--- a/configs/uptrace/grafana/entrypoint.sh
+++ b/configs/uptrace/grafana/entrypoint.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+set -eu
+
+read_secret() {
+	tr -d '\r\n' < "/run/secrets/$1"
+}
+
+uptrace_dsn="$(read_secret uptrace_dsn)"
+case "$uptrace_dsn" in
+	*://*@*/[0-9]*) ;;
+	*)
+		echo "uptrace_dsn must look like http://TOKEN@uptrace:4317/1" >&2
+		exit 1
+		;;
+esac
+
+UPTRACE_PROJECT_TOKEN="${uptrace_dsn#*://}"
+UPTRACE_PROJECT_TOKEN="${UPTRACE_PROJECT_TOKEN%%@*}"
+GF_SECURITY_ADMIN_PASSWORD="$(read_secret grafana_admin_password)"
+
+export UPTRACE_PROJECT_TOKEN
+export GF_SECURITY_ADMIN_PASSWORD
+
+exec /run.sh

--- a/configs/uptrace/grafana/grafana.ini
+++ b/configs/uptrace/grafana/grafana.ini
@@ -1,0 +1,8 @@
+[feature_toggles]
+enable = tempoSearch tempoBackendSearch
+
+[security]
+admin_user = admin
+
+[users]
+default_theme = light

--- a/docker-compose.stack.yml
+++ b/docker-compose.stack.yml
@@ -133,6 +133,7 @@ services:
     networks:
       - twir
       - traefik-public
+      - cloudflared
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "http://localhost/api/health"]
       interval: 30s
@@ -175,6 +176,7 @@ services:
     networks:
       - twir
       - traefik-public
+      - cloudflared
     deploy:
       replicas: 1
       restart_policy:

--- a/docker-compose.stack.yml
+++ b/docker-compose.stack.yml
@@ -157,6 +157,45 @@ services:
         - "traefik.http.routers.twir-uptrace.middlewares=gzip,rate-limit"
         - "traefik.http.services.twir-uptrace.loadbalancer.server.port=80"
 
+  grafana:
+    image: grafana/grafana:12.0.0
+    entrypoint: ["/bin/sh", "/etc/grafana/entrypoint.sh"]
+    configs:
+      - source: uptrace_grafana_datasource
+        target: /etc/grafana/provisioning/datasources/uptrace.yml
+      - source: uptrace_grafana_config
+        target: /etc/grafana/grafana.ini
+      - source: uptrace_grafana_entrypoint
+        target: /etc/grafana/entrypoint.sh
+    secrets:
+      - uptrace_dsn
+      - grafana_admin_password
+    volumes:
+      - grafana-data:/var/lib/grafana
+    networks:
+      - twir
+      - traefik-public
+    deploy:
+      replicas: 1
+      restart_policy:
+        condition: any
+        delay: 5s
+        max_attempts: 30
+      placement:
+        constraints:
+          - node.labels.databases != true
+      resources:
+        limits:
+          memory: 512M
+      labels:
+        - "traefik.enable=true"
+        - "traefik.swarm.network=traefik-public"
+        - "traefik.http.routers.twir-grafana.rule=Host(`grafana.twir.app`)"
+        - "traefik.http.routers.twir-grafana.entrypoints=web"
+        - "traefik.http.routers.twir-grafana.service=twir-grafana"
+        - "traefik.http.routers.twir-grafana.middlewares=gzip,rate-limit"
+        - "traefik.http.services.twir-grafana.loadbalancer.server.port=3000"
+
   otel-collector:
     image: otel/opentelemetry-collector-contrib:0.157.0
     command: ["--config=/etc/otelcol-contrib/config.yaml"]
@@ -1210,6 +1249,12 @@ configs:
     file: ./configs/uptrace/clickhouse/90-disable-system-logs.xml
   uptrace_clickhouse_ttl:
     file: ./configs/uptrace/apply-ttl.sql
+  uptrace_grafana_datasource:
+    file: ./configs/uptrace/grafana/datasource.yml
+  uptrace_grafana_config:
+    file: ./configs/uptrace/grafana/grafana.ini
+  uptrace_grafana_entrypoint:
+    file: ./configs/uptrace/grafana/entrypoint.sh
 
   pgdog_users_config:
     file: ./configs/pgdog/users.toml
@@ -1226,6 +1271,7 @@ volumes:
   clickhouse-data:
   uptrace-clickhouse-data:
   uptrace-postgres-data:
+  grafana-data:
   dbx-data:
 
 networks:
@@ -1257,4 +1303,6 @@ secrets:
   uptrace_clickhouse_password:
     external: true
   uptrace_postgres_password:
+    external: true
+  grafana_admin_password:
     external: true


### PR DESCRIPTION
## Summary

- deploy Grafana 12 at grafana.twir.app
- provision Uptrace as Tempo and Prometheus data sources
- derive the Uptrace authorization token from the existing uptrace_dsn secret
- persist Grafana state in a dedicated Swarm volume
- document generated admin credentials and include the pending project-token setup update

## Deployment notes

- create the external grafana_admin_password secret before deployment
- ensure grafana.twir.app resolves to Traefik
- Grafana uses project 1 from the seeded Uptrace configuration

## Validation

- docker compose config --quiet
- docker stack config
- Grafana 12 startup with provisioning files
- verified uptrace-tempo and uptrace-prometheus through the Grafana API
- shell syntax and git diff checks