### PR TITLE
fix(emotes-cacher): use platform channel ids for 7tv event subscriptions

### DIFF
--- a/apps/emotes-cacher/internal/services/seventv/add_channels.go
+++ b/apps/emotes-cacher/internal/services/seventv/add_channels.go
@@ -60,8 +60,12 @@ var emoteSetSubTypes = []string{"create", "delete"}
 func (c *Service) createSubMessages(data channelsWithEmotesSetsIds) []connSubscription {
 	subMessages := make([]connSubscription, 0, len(data))
 
-	for channelID, platformEntries := range data {
+	for _, platformEntries := range data {
 		for _, entry := range platformEntries {
+			if entry.PlatformID == "" {
+				continue
+			}
+
 			for _, emoteSetSubType := range emoteSetSubTypes {
 				platform := "TWITCH"
 				if strings.EqualFold(entry.Platform, "kick") {
@@ -74,7 +78,7 @@ func (c *Service) createSubMessages(data channelsWithEmotesSetsIds) []connSubscr
 						subType: fmt.Sprintf("emote_set.%s", emoteSetSubType),
 						conditions: map[string]string{
 							"readCtx":  "channel",
-							"id":       channelID,
+							"id":       entry.PlatformID,
 							"platform": platform,
 						},
 					},
@@ -101,6 +105,7 @@ func (c *Service) createSubMessages(data channelsWithEmotesSetsIds) []connSubscr
 type channelWithEmoteSet struct {
 	EmoteSetID string
 	Platform   string
+	PlatformID string
 }
 
 type channelsWithEmotesSetsIds map[string][]channelWithEmoteSet
@@ -199,6 +204,7 @@ func (c *Service) getChannelsWithEmotesSets(
 							channelWithEmoteSet{
 								EmoteSetID: activeEmoteSetID,
 								Platform:   string(binding.Platform),
+								PlatformID: binding.PlatformID,
 							},
 						)
 						if activeEmoteSetID != "" {


### PR DESCRIPTION
## Problem

7TV EventAPI subscriptions for `emote_set.create`/`emote_set.delete` were built with the **internal Twir channel UUID** in the `id` condition:

```
https://events.7tv.io/v3@emote_set.create<readCtx=channel;id=019eae6b-2bcd-...;platform=TWITCH>
```

For `readCtx=channel` 7TV expects the **platform channel id** (Twitch/Kick user id), so these subscriptions never matched anything and channel emote set lifecycle events never arrived.

## Fix

- `channelWithEmoteSet` now carries `PlatformID` (from `channel_platforms.platform_channel_id`).
- `createSubMessages` uses `entry.PlatformID` in the `id` condition instead of the internal channel UUID.

## Consumer audit (id correlation)

Verified every consumer of the emotes store requests emotes with platform channel ids — no downstream changes needed:

| Consumer | Call site | ID passed |
|---|---|---|
| bots | `messagehandler/chat_message.go` | `message.PlatformChannelID` |
| parser (tts) | `commands/tts/say.go` | `parseCtx.Channel.ID` = `binding.PlatformChannelID` |
| eventsub (Twitch) | `handler/chat_message.go` | `msg.BroadcasterUserId` |
| eventsub (Kick) | `kick/handlers.go` | `platformChannelID` (broadcaster user id) |

The store itself is keyed by `ChannelKey{Platform, PlatformID}` everywhere (`fillChannels`, `emoteSetToChannelID`), so the fix restores end-to-end consistency.

## Verification

- `go build ./...` — ok
- `go vet ./...` — ok
- `go test ./internal/services/seventv/...` — 2 passed

Note: existing sockets with wrong subscription conditions are recreated only on service restart.