### PR TITLE
feat(url-shortener): restore banned user agents presets UI

### DIFF
--- a/web/layers/url-shortener/components/url-shortener/banned-ua-dialog.vue
+++ b/web/layers/url-shortener/components/url-shortener/banned-ua-dialog.vue
@@ -1,0 +1,362 @@
+<script setup lang="ts">
+import { storeToRefs } from 'pinia'
+import { toast } from 'vue-sonner'
+
+import Button from '@/components/ui/button/Button.vue'
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogHeader,
+	DialogTitle,
+} from '@/components/ui/dialog'
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from '@/components/ui/select'
+
+import { useUrlShortener } from '../../composables/use-url-shortener'
+
+const props = defineProps<{
+	open: boolean
+	linkId: string
+	shortUrl: string
+}>()
+
+const emit = defineEmits<{
+	(e: 'update:open', value: boolean): void
+}>()
+
+const urlShortener = useUrlShortener()
+const {
+	bannedUaPresets,
+	presetPatterns,
+	linkPresets,
+	isLinkPresetsLoading,
+	perLinkBannedUserAgents,
+	isPerLinkBannedUserAgentsLoading,
+} = storeToRefs(urlShortener)
+
+const selectedPresetId = ref('')
+const isApplyingPreset = ref(false)
+const removingPresetId = ref<string | null>(null)
+
+const patternInput = ref('')
+const descriptionInput = ref('')
+const errorMessage = ref<string | null>(null)
+const isCreatingPattern = ref(false)
+const deletingPatternId = ref<string | null>(null)
+
+const appliedLinkPresets = computed(() => linkPresets.value.get(props.linkId) ?? [])
+const appliedPresetIds = computed(
+	() => new Set(appliedLinkPresets.value.map((item) => item.preset_id))
+)
+const availablePresets = computed(() =>
+	bannedUaPresets.value.filter((preset) => !appliedPresetIds.value.has(preset.id))
+)
+const linkPatterns = computed(() => perLinkBannedUserAgents.value.get(props.linkId) ?? [])
+
+function presetName(presetId: string) {
+	return bannedUaPresets.value.find((preset) => preset.id === presetId)?.name ?? 'Unknown preset'
+}
+
+function presetPatternCount(presetId: string) {
+	return presetPatterns.value.get(presetId)?.length ?? 0
+}
+
+watch(
+	() => props.open,
+	async (isOpen) => {
+		if (!isOpen || !import.meta.client) return
+
+		selectedPresetId.value = ''
+		errorMessage.value = null
+		patternInput.value = ''
+		descriptionInput.value = ''
+
+		if (!bannedUaPresets.value.length) {
+			await urlShortener.fetchBannedUaPresets()
+		}
+
+		await Promise.all([
+			urlShortener.fetchLinkPresets(props.linkId),
+			urlShortener.fetchPerLinkBannedUserAgents(props.linkId),
+			...bannedUaPresets.value.map((preset) => urlShortener.fetchPresetPatterns(preset.id)),
+		])
+	}
+)
+
+async function handleApplyPreset() {
+	if (!selectedPresetId.value) return
+
+	isApplyingPreset.value = true
+	errorMessage.value = null
+
+	const { error } = await urlShortener.applyPresetToLink(props.linkId, selectedPresetId.value)
+	if (error) {
+		errorMessage.value = error.toString()
+	} else {
+		toast.success('Preset applied', {
+			description: `All patterns from "${presetName(selectedPresetId.value)}" now apply to this link.`,
+		})
+		selectedPresetId.value = ''
+	}
+
+	isApplyingPreset.value = false
+}
+
+async function handleRemovePreset(presetId: string) {
+	removingPresetId.value = presetId
+	errorMessage.value = null
+
+	const { error } = await urlShortener.removePresetFromLink(props.linkId, presetId)
+	if (error) {
+		errorMessage.value = error.toString()
+	} else {
+		toast.success('Preset removed')
+	}
+
+	removingPresetId.value = null
+}
+
+function isValidRegex(pattern: string): boolean {
+	try {
+		return Boolean(new RegExp(pattern))
+	} catch {
+		return false
+	}
+}
+
+async function handleCreatePattern() {
+	const pattern = patternInput.value.trim()
+	if (!pattern) {
+		errorMessage.value = 'Enter a regex pattern to continue'
+		return
+	}
+
+	if (!isValidRegex(pattern)) {
+		errorMessage.value = 'Invalid regex pattern'
+		return
+	}
+
+	isCreatingPattern.value = true
+	errorMessage.value = null
+
+	const { error } = await urlShortener.createPerLinkBannedUserAgent(props.linkId, {
+		pattern,
+		description: descriptionInput.value.trim() || null,
+	})
+
+	if (error) {
+		errorMessage.value = error.toString()
+		isCreatingPattern.value = false
+		return
+	}
+
+	patternInput.value = ''
+	descriptionInput.value = ''
+	toast.success('Pattern added', {
+		description: 'User agents matching this pattern will receive a 404 response.',
+	})
+	isCreatingPattern.value = false
+}
+
+async function handleDeletePattern(id: string) {
+	deletingPatternId.value = id
+	errorMessage.value = null
+
+	const { error } = await urlShortener.deletePerLinkBannedUserAgent(props.linkId, id)
+	if (error) {
+		errorMessage.value = error.toString()
+	} else {
+		toast.success('Pattern removed')
+	}
+
+	deletingPatternId.value = null
+}
+
+function closeDialog() {
+	emit('update:open', false)
+}
+</script>
+
+<template>
+	<Dialog :open="open" @update:open="closeDialog">
+		<DialogContent class="max-w-lg max-h-[85vh] overflow-y-auto">
+			<DialogHeader>
+				<DialogTitle>Banned User Agents</DialogTitle>
+				<DialogDescription>
+					Block specific clients (e.g. Chatterino) from seeing previews for
+					<span class="font-mono">{{ shortUrl }}</span> using regex patterns.
+				</DialogDescription>
+			</DialogHeader>
+
+			<div class="space-y-4">
+				<div class="space-y-3">
+					<h3 class="text-sm font-semibold">Presets applied to this link</h3>
+
+					<p v-if="isLinkPresetsLoading.get(linkId)" class="text-sm text-[hsl(240,11%,70%)]">
+						Loading presets...
+					</p>
+					<p v-else-if="!appliedLinkPresets.length" class="text-xs text-[hsl(240,11%,55%)]">
+						No presets applied. Apply one below or manage presets on the main page.
+					</p>
+					<ul v-else class="space-y-2">
+						<li
+							v-for="linkPreset in appliedLinkPresets"
+							:key="linkPreset.id"
+							class="flex items-center justify-between gap-3 rounded-lg border border-[hsl(240,11%,20%)] bg-[hsl(240,11%,15%)] px-3 py-2"
+						>
+							<div class="min-w-0 flex-1">
+								<p class="text-sm font-medium truncate">{{ presetName(linkPreset.preset_id) }}</p>
+								<p class="text-xs text-[hsl(240,11%,55%)]">
+									{{ presetPatternCount(linkPreset.preset_id) }} pattern{{ presetPatternCount(linkPreset.preset_id) === 1 ? '' : 's' }}
+								</p>
+							</div>
+							<button
+								:disabled="removingPresetId === linkPreset.preset_id"
+								class="flex-shrink-0 rounded-md p-1 text-[hsl(240,11%,55%)] hover:text-red-400 hover:bg-[hsl(240,11%,18%)] transition-colors disabled:opacity-50"
+								title="Remove preset from link"
+								@click="handleRemovePreset(linkPreset.preset_id)"
+							>
+								<Icon
+									v-if="removingPresetId === linkPreset.preset_id"
+									name="lucide:loader-2"
+									class="h-4 w-4 animate-spin"
+								/>
+								<Icon v-else name="lucide:x" class="h-4 w-4" />
+							</button>
+						</li>
+					</ul>
+
+					<div v-if="availablePresets.length" class="flex gap-2">
+						<Select v-model="selectedPresetId">
+							<SelectTrigger
+								class="flex-1 border-[hsl(240,11%,25%)] bg-[hsl(240,11%,15%)] hover:bg-[hsl(240,11%,20%)] transition-colors"
+							>
+								<SelectValue placeholder="Select a preset" />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem v-for="preset in availablePresets" :key="preset.id" :value="preset.id">
+									{{ preset.name }}
+								</SelectItem>
+							</SelectContent>
+						</Select>
+						<Button
+							type="button"
+							variant="outline"
+							size="sm"
+							class="border-[hsl(240,11%,25%)] bg-[hsl(240,11%,15%)] hover:bg-[hsl(240,11%,20%)]"
+							:disabled="!selectedPresetId || isApplyingPreset"
+							@click="handleApplyPreset"
+						>
+							<Icon v-if="isApplyingPreset" name="lucide:loader-2" class="h-4 w-4 mr-2 animate-spin" />
+							Apply
+						</Button>
+					</div>
+					<p v-else-if="bannedUaPresets.length" class="text-xs text-[hsl(240,11%,55%)]">
+						All presets are already applied to this link.
+					</p>
+					<p v-else class="text-xs text-[hsl(240,11%,55%)]">
+						No presets yet. Create one in the Banned User Agent Presets panel on the main page.
+					</p>
+				</div>
+
+				<div class="space-y-3 border-t border-[hsl(240,11%,18%)] pt-4">
+					<h3 class="text-sm font-semibold">Per-link banned user agents</h3>
+
+					<p
+						v-if="isPerLinkBannedUserAgentsLoading.get(linkId)"
+						class="text-sm text-[hsl(240,11%,70%)]"
+					>
+						Loading patterns...
+					</p>
+					<p v-else-if="!linkPatterns.length" class="text-xs text-[hsl(240,11%,55%)]">
+						No per-link patterns. These apply only to this link.
+					</p>
+					<ul v-else class="space-y-2">
+						<li
+							v-for="pattern in linkPatterns"
+							:key="pattern.id"
+							class="flex items-start justify-between gap-3 rounded-lg border border-[hsl(240,11%,20%)] bg-[hsl(240,11%,15%)] px-3 py-2"
+						>
+							<div class="min-w-0 flex-1">
+								<p class="font-mono text-sm text-[hsl(240,11%,90%)] break-all">
+									{{ pattern.pattern }}
+								</p>
+								<p v-if="pattern.description" class="text-xs text-[hsl(240,11%,55%)] mt-0.5">
+									{{ pattern.description }}
+								</p>
+							</div>
+							<button
+								:disabled="deletingPatternId === pattern.id"
+								class="flex-shrink-0 rounded-md p-1 text-[hsl(240,11%,55%)] hover:text-red-400 hover:bg-[hsl(240,11%,18%)] transition-colors disabled:opacity-50"
+								title="Delete pattern"
+								@click="handleDeletePattern(pattern.id)"
+							>
+								<Icon
+									v-if="deletingPatternId === pattern.id"
+									name="lucide:loader-2"
+									class="h-4 w-4 animate-spin"
+								/>
+								<Icon v-else name="lucide:trash-2" class="h-4 w-4" />
+							</button>
+						</li>
+					</ul>
+
+					<div class="space-y-3">
+						<div class="flex flex-col gap-2">
+							<label class="text-xs text-[hsl(240,11%,60%)]" for="link-ua-pattern">
+								Regex pattern <span class="text-red-400">*</span>
+							</label>
+							<input
+								id="link-ua-pattern"
+								v-model="patternInput"
+								type="text"
+								maxlength="512"
+								placeholder="Chatterino|TwitchLib"
+								class="rounded-lg border border-[hsl(240,11%,20%)] bg-[hsl(240,11%,15%)] px-3 py-2 text-sm text-white placeholder-[hsl(240,11%,45%)] focus-visible:outline-none focus-visible:ring focus-visible:ring-[hsl(240,11%,30%)]"
+							/>
+						</div>
+						<div class="flex flex-col gap-2">
+							<label class="text-xs text-[hsl(240,11%,60%)]" for="link-ua-description">
+								Description <span class="text-[hsl(240,11%,45%)]">(optional)</span>
+							</label>
+							<input
+								id="link-ua-description"
+								v-model="descriptionInput"
+								type="text"
+								maxlength="256"
+								placeholder="Block Chatterino previews"
+								class="rounded-lg border border-[hsl(240,11%,20%)] bg-[hsl(240,11%,15%)] px-3 py-2 text-sm text-white placeholder-[hsl(240,11%,45%)] focus-visible:outline-none focus-visible:ring focus-visible:ring-[hsl(240,11%,30%)]"
+							/>
+						</div>
+						<Button
+							type="button"
+							variant="outline"
+							size="sm"
+							class="border-[hsl(240,11%,25%)] bg-[hsl(240,11%,15%)] hover:bg-[hsl(240,11%,20%)]"
+							:disabled="isCreatingPattern"
+							@click="handleCreatePattern"
+						>
+							<Icon v-if="isCreatingPattern" name="lucide:loader-2" class="h-4 w-4 mr-2 animate-spin" />
+							<Icon v-else name="lucide:plus" class="h-4 w-4 mr-2" />
+							Add pattern
+						</Button>
+						<p class="text-xs text-[hsl(240,11%,55%)]">
+							Use a valid JavaScript regex. Matching is case-insensitive against the full
+							<span class="font-mono">User-Agent</span> header.
+						</p>
+					</div>
+				</div>
+
+				<p v-if="errorMessage" class="text-sm text-red-400">
+					{{ errorMessage }}
+				</p>
+			</div>
+		</DialogContent>
+	</Dialog>
+</template>

--- a/web/layers/url-shortener/components/url-shortener/banned-ua-presets-panel.vue
+++ b/web/layers/url-shortener/components/url-shortener/banned-ua-presets-panel.vue
@@ -1,0 +1,506 @@
+<script setup lang="ts">
+import { storeToRefs } from 'pinia'
+import { toast } from 'vue-sonner'
+
+import ActionConfirm from '@/components/ui/action-confirm/ActionConfirm.vue'
+
+import { useUrlShortener } from '../../composables/use-url-shortener'
+import { UserStoreKey } from '~/stores/user'
+
+const userStore = useAuth()
+await callOnce(UserStoreKey, () => userStore.getUserDataWithoutDashboards())
+
+const urlShortener = useUrlShortener()
+const { bannedUaPresets, isBannedUaPresetsLoading, presetPatterns, isPresetPatternsLoading } =
+	storeToRefs(urlShortener)
+
+const presetNameInput = ref('')
+const presetDescriptionInput = ref('')
+const errorMessage = ref<string | null>(null)
+const isCreatingPreset = ref(false)
+
+const editingPresetId = ref<string | null>(null)
+const editingName = ref('')
+const editingDescription = ref('')
+const isSavingEdit = ref(false)
+
+const presetPendingDeleteId = ref<string | null>(null)
+
+const patternInputs = ref<Map<string, string>>(new Map())
+const patternDescriptionInputs = ref<Map<string, string>>(new Map())
+const patternErrors = ref<Map<string, string | null>>(new Map())
+const creatingPatternPresetId = ref<string | null>(null)
+const deletingPatternId = ref<string | null>(null)
+
+const isAuthenticated = computed(() => Boolean(userStore.userWithoutDashboards))
+
+const presetPendingDelete = computed(
+	() => bannedUaPresets.value.find((preset) => preset.id === presetPendingDeleteId.value) ?? null
+)
+
+const isDeleteConfirmOpen = computed({
+	get: () => presetPendingDeleteId.value !== null,
+	set: (value: boolean) => {
+		if (!value) {
+			presetPendingDeleteId.value = null
+		}
+	},
+})
+
+async function refresh() {
+	errorMessage.value = null
+
+	if (!isAuthenticated.value) {
+		bannedUaPresets.value = []
+		presetPatterns.value = new Map()
+		return
+	}
+
+	const { error } = await urlShortener.fetchBannedUaPresets()
+	if (error) {
+		errorMessage.value = error.toString()
+		return
+	}
+
+	await Promise.all(
+		bannedUaPresets.value.map((preset) => urlShortener.fetchPresetPatterns(preset.id))
+	)
+}
+
+await refresh()
+
+watch(
+	() => isAuthenticated.value,
+	(value) => {
+		if (!value) {
+			bannedUaPresets.value = []
+			presetPatterns.value = new Map()
+			return
+		}
+		refresh()
+	}
+)
+
+async function handleCreatePreset() {
+	const name = presetNameInput.value.trim()
+	if (!name) {
+		errorMessage.value = 'Enter a preset name to continue'
+		return
+	}
+
+	isCreatingPreset.value = true
+	errorMessage.value = null
+
+	const { error } = await urlShortener.createBannedUaPreset({
+		name,
+		description: presetDescriptionInput.value.trim() || null,
+	})
+
+	if (error) {
+		errorMessage.value = error.toString()
+		isCreatingPreset.value = false
+		return
+	}
+
+	presetNameInput.value = ''
+	presetDescriptionInput.value = ''
+	toast.success('Preset created', {
+		description: 'Add regex patterns to it, then apply it to your links.',
+	})
+	isCreatingPreset.value = false
+}
+
+function startEdit(presetId: string) {
+	const preset = bannedUaPresets.value.find((item) => item.id === presetId)
+	if (!preset) return
+
+	editingPresetId.value = presetId
+	editingName.value = preset.name
+	editingDescription.value = preset.description ?? ''
+}
+
+function cancelEdit() {
+	editingPresetId.value = null
+	editingName.value = ''
+	editingDescription.value = ''
+}
+
+async function handleSaveEdit(presetId: string) {
+	const name = editingName.value.trim()
+	if (!name) {
+		errorMessage.value = 'Preset name cannot be empty'
+		return
+	}
+
+	isSavingEdit.value = true
+	errorMessage.value = null
+
+	const { error } = await urlShortener.updateBannedUaPreset(presetId, {
+		name,
+		description: editingDescription.value.trim() || null,
+	})
+
+	if (error) {
+		errorMessage.value = error.toString()
+		isSavingEdit.value = false
+		return
+	}
+
+	toast.success('Preset updated')
+	cancelEdit()
+	isSavingEdit.value = false
+}
+
+async function handleDeletePreset() {
+	const presetId = presetPendingDeleteId.value
+	if (!presetId) return
+
+	errorMessage.value = null
+
+	const { error } = await urlShortener.deleteBannedUaPreset(presetId)
+	if (error) {
+		errorMessage.value = error.toString()
+	} else {
+		toast.success('Preset deleted')
+	}
+
+	if (editingPresetId.value === presetId) {
+		cancelEdit()
+	}
+
+	presetPendingDeleteId.value = null
+}
+
+function setPatternInput(presetId: string, value: string) {
+	patternInputs.value.set(presetId, value)
+}
+
+function setPatternDescriptionInput(presetId: string, value: string) {
+	patternDescriptionInputs.value.set(presetId, value)
+}
+
+function isValidRegex(pattern: string): boolean {
+	try {
+		return Boolean(new RegExp(pattern))
+	} catch {
+		return false
+	}
+}
+
+async function handleCreatePattern(presetId: string) {
+	const pattern = (patternInputs.value.get(presetId) ?? '').trim()
+	if (!pattern) {
+		patternErrors.value.set(presetId, 'Enter a regex pattern to continue')
+		return
+	}
+
+	if (!isValidRegex(pattern)) {
+		patternErrors.value.set(presetId, 'Invalid regex pattern')
+		return
+	}
+
+	creatingPatternPresetId.value = presetId
+	patternErrors.value.set(presetId, null)
+
+	const { error } = await urlShortener.createPresetPattern(presetId, {
+		pattern,
+		description: (patternDescriptionInputs.value.get(presetId) ?? '').trim() || null,
+	})
+
+	if (error) {
+		patternErrors.value.set(presetId, error.toString())
+		creatingPatternPresetId.value = null
+		return
+	}
+
+	patternInputs.value.set(presetId, '')
+	patternDescriptionInputs.value.set(presetId, '')
+	toast.success('Pattern added', {
+		description: 'User agents matching this pattern will receive a 404 response.',
+	})
+	creatingPatternPresetId.value = null
+}
+
+async function handleDeletePattern(presetId: string, patternId: string) {
+	deletingPatternId.value = patternId
+
+	const { error } = await urlShortener.deletePresetPattern(presetId, patternId)
+	if (error) {
+		patternErrors.value.set(presetId, error.toString())
+	} else {
+		toast.success('Pattern removed')
+	}
+
+	deletingPatternId.value = null
+}
+</script>
+
+<template>
+	<div
+		class="flex w-full max-w-xl border border-[hsl(240,11%,18%)] bg-[hsl(240,11%,9%)] rounded-2xl p-4 shadow-[0px_0px_30px_hsl(240,11%,6%)]"
+	>
+		<details class="group w-full">
+			<summary class="flex items-start justify-between gap-4 cursor-pointer list-none">
+				<div class="space-y-1">
+					<h2 class="text-lg font-semibold">Banned User Agent Presets</h2>
+					<p class="text-sm text-[hsl(240,11%,60%)]">
+						Group regex patterns into named presets and apply them to your short links.
+					</p>
+					<p v-if="!isAuthenticated" class="text-xs text-[hsl(240,11%,55%)]">
+						Sign in to manage banned user agent presets.
+					</p>
+				</div>
+				<div class="flex items-center gap-2">
+					<span
+						v-if="isAuthenticated"
+						class="inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-semibold border-[hsl(240,11%,24%)] text-[hsl(240,11%,70%)]"
+					>
+						{{ bannedUaPresets.length }} preset{{ bannedUaPresets.length === 1 ? '' : 's' }}
+					</span>
+					<Icon
+						name="lucide:chevron-down"
+						class="h-4 w-4 text-[hsl(240,11%,55%)] transition-transform group-open:rotate-180"
+					/>
+				</div>
+			</summary>
+
+			<div class="mt-4 flex flex-col gap-4">
+				<div
+					v-if="!isAuthenticated"
+					class="rounded-xl border border-[hsl(240,11%,18%)] bg-[hsl(240,11%,12%)] p-4"
+				>
+					<p class="text-sm text-[hsl(240,11%,70%)]">
+						Banned user agent presets are available only for authorized users.
+					</p>
+					<UiButton class="mt-3" @click="userStore.login">Login</UiButton>
+				</div>
+
+				<div v-else class="space-y-4">
+					<div
+						v-if="isBannedUaPresetsLoading"
+						class="rounded-xl border border-[hsl(240,11%,18%)] bg-[hsl(240,11%,12%)] p-4"
+					>
+						<p class="text-sm text-[hsl(240,11%,70%)]">Loading presets...</p>
+					</div>
+
+					<template v-else>
+						<div
+							v-for="preset in bannedUaPresets"
+							:key="preset.id"
+							class="rounded-xl border border-[hsl(240,11%,18%)] bg-[hsl(240,11%,12%)] p-4 space-y-3"
+						>
+							<div v-if="editingPresetId === preset.id" class="space-y-3">
+								<div class="flex flex-col gap-2">
+									<label class="text-xs text-[hsl(240,11%,60%)]" :for="`preset-edit-name-${preset.id}`">
+										Name <span class="text-red-400">*</span>
+									</label>
+									<input
+										:id="`preset-edit-name-${preset.id}`"
+										v-model="editingName"
+										type="text"
+										maxlength="100"
+										class="rounded-lg border border-[hsl(240,11%,20%)] bg-[hsl(240,11%,15%)] px-3 py-2 text-sm text-white placeholder-[hsl(240,11%,45%)] focus-visible:outline-none focus-visible:ring focus-visible:ring-[hsl(240,11%,30%)]"
+									/>
+								</div>
+								<div class="flex flex-col gap-2">
+									<label class="text-xs text-[hsl(240,11%,60%)]" :for="`preset-edit-description-${preset.id}`">
+										Description <span class="text-[hsl(240,11%,45%)]">(optional)</span>
+									</label>
+									<input
+										:id="`preset-edit-description-${preset.id}`"
+										v-model="editingDescription"
+										type="text"
+										maxlength="256"
+										class="rounded-lg border border-[hsl(240,11%,20%)] bg-[hsl(240,11%,15%)] px-3 py-2 text-sm text-white placeholder-[hsl(240,11%,45%)] focus-visible:outline-none focus-visible:ring focus-visible:ring-[hsl(240,11%,30%)]"
+									/>
+								</div>
+								<div class="flex flex-wrap gap-2">
+									<UiButton variant="outline" size="sm" :disabled="isSavingEdit" @click="cancelEdit">
+										Cancel
+									</UiButton>
+									<UiButton size="sm" :disabled="isSavingEdit" @click="handleSaveEdit(preset.id)">
+										<Icon
+											v-if="isSavingEdit"
+											name="lucide:loader-2"
+											class="mr-2 h-4 w-4 animate-spin"
+										/>
+										Save
+									</UiButton>
+								</div>
+							</div>
+
+							<div v-else class="flex items-start justify-between gap-3">
+								<div class="min-w-0 flex-1">
+									<p class="font-semibold truncate">{{ preset.name }}</p>
+									<p v-if="preset.description" class="text-xs text-[hsl(240,11%,55%)] mt-0.5">
+										{{ preset.description }}
+									</p>
+								</div>
+								<div class="flex items-center gap-1">
+									<button
+										class="flex-shrink-0 rounded-md p-1 text-[hsl(240,11%,55%)] hover:text-white hover:bg-[hsl(240,11%,18%)] transition-colors"
+										title="Edit preset"
+										@click="startEdit(preset.id)"
+									>
+										<Icon name="lucide:pencil" class="h-4 w-4" />
+									</button>
+									<button
+										class="flex-shrink-0 rounded-md p-1 text-[hsl(240,11%,55%)] hover:text-red-400 hover:bg-[hsl(240,11%,18%)] transition-colors"
+										title="Delete preset"
+										@click="presetPendingDeleteId = preset.id"
+									>
+										<Icon name="lucide:trash-2" class="h-4 w-4" />
+									</button>
+								</div>
+							</div>
+
+							<div class="space-y-2">
+								<p class="text-xs uppercase tracking-wide text-[hsl(240,11%,60%)]">Patterns</p>
+								<p
+									v-if="isPresetPatternsLoading.get(preset.id)"
+									class="text-sm text-[hsl(240,11%,70%)]"
+								>
+									Loading patterns...
+								</p>
+								<p
+									v-else-if="!(presetPatterns.get(preset.id) ?? []).length"
+									class="text-xs text-[hsl(240,11%,55%)]"
+								>
+									No patterns yet. Add one below.
+								</p>
+								<ul v-else class="space-y-2">
+									<li
+										v-for="pattern in presetPatterns.get(preset.id) ?? []"
+										:key="pattern.id"
+										class="flex items-start justify-between gap-3 rounded-lg border border-[hsl(240,11%,20%)] bg-[hsl(240,11%,15%)] px-3 py-2"
+									>
+										<div class="min-w-0 flex-1">
+											<p class="font-mono text-sm text-[hsl(240,11%,90%)] break-all">
+												{{ pattern.pattern }}
+											</p>
+											<p v-if="pattern.description" class="text-xs text-[hsl(240,11%,55%)] mt-0.5">
+												{{ pattern.description }}
+											</p>
+										</div>
+										<button
+											:disabled="deletingPatternId === pattern.id"
+											class="flex-shrink-0 rounded-md p-1 text-[hsl(240,11%,55%)] hover:text-red-400 hover:bg-[hsl(240,11%,18%)] transition-colors disabled:opacity-50"
+											title="Delete pattern"
+											@click="handleDeletePattern(preset.id, pattern.id)"
+										>
+											<Icon
+												v-if="deletingPatternId === pattern.id"
+												name="lucide:loader-2"
+												class="h-4 w-4 animate-spin"
+											/>
+											<Icon v-else name="lucide:trash-2" class="h-4 w-4" />
+										</button>
+									</li>
+								</ul>
+							</div>
+
+							<div class="space-y-3 rounded-lg border border-[hsl(240,11%,20%)] bg-[hsl(240,11%,15%)] p-3">
+								<div class="flex flex-col gap-2">
+									<label class="text-xs text-[hsl(240,11%,60%)]" :for="`preset-pattern-${preset.id}`">
+										Regex pattern <span class="text-red-400">*</span>
+									</label>
+									<input
+										:id="`preset-pattern-${preset.id}`"
+										:value="patternInputs.get(preset.id) ?? ''"
+										type="text"
+										maxlength="512"
+										placeholder="Chatterino|TwitchLib"
+										class="rounded-lg border border-[hsl(240,11%,20%)] bg-[hsl(240,11%,15%)] px-3 py-2 text-sm text-white placeholder-[hsl(240,11%,45%)] focus-visible:outline-none focus-visible:ring focus-visible:ring-[hsl(240,11%,30%)]"
+										@input="setPatternInput(preset.id, ($event.target as HTMLInputElement).value)"
+									/>
+								</div>
+								<div class="flex flex-col gap-2">
+									<label class="text-xs text-[hsl(240,11%,60%)]" :for="`preset-pattern-description-${preset.id}`">
+										Description <span class="text-[hsl(240,11%,45%)]">(optional)</span>
+									</label>
+									<input
+										:id="`preset-pattern-description-${preset.id}`"
+										:value="patternDescriptionInputs.get(preset.id) ?? ''"
+										type="text"
+										maxlength="256"
+										placeholder="Block Chatterino previews"
+										class="rounded-lg border border-[hsl(240,11%,20%)] bg-[hsl(240,11%,15%)] px-3 py-2 text-sm text-white placeholder-[hsl(240,11%,45%)] focus-visible:outline-none focus-visible:ring focus-visible:ring-[hsl(240,11%,30%)]"
+										@input="setPatternDescriptionInput(preset.id, ($event.target as HTMLInputElement).value)"
+									/>
+								</div>
+								<UiButton
+									size="sm"
+									:disabled="creatingPatternPresetId === preset.id"
+									@click="handleCreatePattern(preset.id)"
+								>
+									<Icon
+										v-if="creatingPatternPresetId === preset.id"
+										name="lucide:loader-2"
+										class="mr-2 h-4 w-4 animate-spin"
+									/>
+									<Icon v-else name="lucide:plus" class="mr-2 h-4 w-4" />
+									Add pattern
+								</UiButton>
+								<p v-if="patternErrors.get(preset.id)" class="text-sm text-red-400">
+									{{ patternErrors.get(preset.id) }}
+								</p>
+								<p class="text-xs text-[hsl(240,11%,55%)]">
+									Use a valid JavaScript regex. Matching is case-insensitive against the full
+									<span class="font-mono">User-Agent</span> header.
+								</p>
+							</div>
+						</div>
+
+						<div class="rounded-xl border border-[hsl(240,11%,18%)] bg-[hsl(240,11%,12%)] p-4 space-y-3">
+							<p class="text-xs uppercase tracking-wide text-[hsl(240,11%,60%)]">Create preset</p>
+							<div class="flex flex-col gap-2">
+								<label class="text-xs text-[hsl(240,11%,60%)]" for="preset-name">
+									Name <span class="text-red-400">*</span>
+								</label>
+								<input
+									id="preset-name"
+									v-model="presetNameInput"
+									type="text"
+									maxlength="100"
+									placeholder="Chat clients"
+									class="rounded-lg border border-[hsl(240,11%,20%)] bg-[hsl(240,11%,15%)] px-3 py-2 text-sm text-white placeholder-[hsl(240,11%,45%)] focus-visible:outline-none focus-visible:ring focus-visible:ring-[hsl(240,11%,30%)]"
+								/>
+							</div>
+							<div class="flex flex-col gap-2">
+								<label class="text-xs text-[hsl(240,11%,60%)]" for="preset-description">
+									Description <span class="text-[hsl(240,11%,45%)]">(optional)</span>
+								</label>
+								<input
+									id="preset-description"
+									v-model="presetDescriptionInput"
+									type="text"
+									maxlength="256"
+									placeholder="Block known chat clients from link previews"
+									class="rounded-lg border border-[hsl(240,11%,20%)] bg-[hsl(240,11%,15%)] px-3 py-2 text-sm text-white placeholder-[hsl(240,11%,45%)] focus-visible:outline-none focus-visible:ring focus-visible:ring-[hsl(240,11%,30%)]"
+								/>
+							</div>
+							<UiButton :disabled="isCreatingPreset" @click="handleCreatePreset">
+								<Icon v-if="isCreatingPreset" name="lucide:loader-2" class="mr-2 h-4 w-4 animate-spin" />
+								<Icon v-else name="lucide:plus" class="mr-2 h-4 w-4" />
+								Create preset
+							</UiButton>
+						</div>
+					</template>
+
+					<p v-if="errorMessage" class="text-sm text-red-400">
+						{{ errorMessage }}
+					</p>
+				</div>
+			</div>
+		</details>
+
+		<ClientOnly>
+			<ActionConfirm
+				v-model:open="isDeleteConfirmOpen"
+				:confirm-text="`Delete preset '${presetPendingDelete?.name ?? ''}' and all its patterns? Links using it will lose this protection.`"
+				@confirm="handleDeletePreset"
+				@cancel="presetPendingDeleteId = null"
+			/>
+		</ClientOnly>
+	</div>
+</template>

--- a/web/layers/url-shortener/components/url-shortener/form.vue
+++ b/web/layers/url-shortener/components/url-shortener/form.vue
@@ -2,12 +2,18 @@
 import { useForm } from 'vee-validate'
 import * as z from 'zod'
 import { storeToRefs } from 'pinia'
+import { toast } from 'vue-sonner'
 
 import { useUrlShortener } from '../../composables/use-url-shortener'
+import { UserStoreKey } from '~/stores/user'
 
 import type { LinkOutputDto } from '@twir/api/openapi'
 
 const twirShortenerUrl = useRequestURL()
+
+const userStore = useAuth()
+await callOnce(UserStoreKey, () => userStore.getUserDataWithoutDashboards())
+const isAuthenticated = computed(() => Boolean(userStore.userWithoutDashboards))
 
 const schema = z.object({
 	url: z
@@ -34,9 +40,31 @@ const form = useForm({
 })
 
 const api = useUrlShortener()
-const { customDomain } = storeToRefs(api)
+const { customDomain, bannedUaPresets } = storeToRefs(api)
 const currentUrl = ref<LinkOutputDto>()
 const currentError = ref<string>()
+
+const selectedPresetIds = ref<string[]>([])
+
+function togglePreset(presetId: string) {
+	if (selectedPresetIds.value.includes(presetId)) {
+		selectedPresetIds.value = selectedPresetIds.value.filter((id) => id !== presetId)
+	} else {
+		selectedPresetIds.value = [...selectedPresetIds.value, presetId]
+	}
+}
+
+watch(
+	isAuthenticated,
+	async (authenticated) => {
+		if (!authenticated || !import.meta.client) {
+			if (!authenticated) selectedPresetIds.value = []
+			return
+		}
+		await api.fetchBannedUaPresets()
+	},
+	{ immediate: true }
+)
 const { setFieldValue, values } = form
 const hasVerifiedCustomDomain = computed(
 	() => Boolean(customDomain.value?.domain && customDomain.value?.verified)
@@ -93,6 +121,23 @@ const onSubmit = form.handleSubmit(async (values) => {
 	}
 
 	currentUrl.value = data.data
+
+	if (selectedPresetIds.value.length) {
+		const results = await Promise.all(
+			selectedPresetIds.value.map((presetId) => api.applyPresetToLink(data.data.id, presetId))
+		)
+		const failed = results.filter((result) => result.error).length
+		if (failed > 0) {
+			toast.error('Some presets were not applied', {
+				description: `${failed} of ${selectedPresetIds.value.length} presets failed to apply. You can apply them from the link card.`,
+			})
+		} else {
+			toast.success('Presets applied', {
+				description: 'Selected banned user agent presets are active on the new link.',
+			})
+		}
+	}
+
 	form.resetForm({
 		values: {
 			url: '',
@@ -100,6 +145,7 @@ const onSubmit = form.handleSubmit(async (values) => {
 			useCustomDomain: values.useCustomDomain ?? false,
 		},
 	})
+	selectedPresetIds.value = []
 })
 </script>
 
@@ -207,11 +253,38 @@ const onSubmit = form.handleSubmit(async (values) => {
 										Verify your custom domain to use it for new links. Until then, links use
 										{{ twirShortenerUrl.origin + '/s/' }}.
 									</p>
-									<UiFormMessage class="text-xs" />
-								</div>
-							</UiFormItem>
-						</UiFormField>
-					</UiAccordionContent>
+								<UiFormMessage class="text-xs" />
+							</div>
+						</UiFormItem>
+					</UiFormField>
+					<div
+						v-if="isAuthenticated && bannedUaPresets.length"
+						class="flex flex-col gap-2 px-2 pb-3 mt-3"
+					>
+						<span class="font-medium text-sm">Banned user agent presets</span>
+						<div class="flex flex-wrap gap-2">
+							<button
+								v-for="preset in bannedUaPresets"
+								:key="preset.id"
+								type="button"
+								class="flex items-center gap-1.5 rounded-lg border px-2.5 py-1.5 text-xs font-semibold transition-colors"
+								:class="
+									selectedPresetIds.includes(preset.id)
+										? 'border-[hsl(240,11%,45%)] bg-[hsl(240,11%,30%)] text-white'
+										: 'border-[hsl(240,11%,25%)] bg-[hsl(240,11%,15%)] text-[hsl(240,11%,60%)] hover:bg-[hsl(240,11%,20%)]'
+								"
+								@click="togglePreset(preset.id)"
+							>
+								<Icon name="lucide:shield-ban" class="h-3.5 w-3.5" />
+								{{ preset.name }}
+							</button>
+						</div>
+						<p class="text-xs text-[hsl(240,11%,55%)]">
+							Selected presets will be applied to the new link right after creation. Manage presets
+							in the panel below.
+						</p>
+					</div>
+				</UiAccordionContent>
 				</UiAccordionItem>
 			</UiAccordion>
 

--- a/web/layers/url-shortener/components/url-shortener/link-card-with-stats.vue
+++ b/web/layers/url-shortener/components/url-shortener/link-card-with-stats.vue
@@ -14,6 +14,7 @@ import ViewsHistoryDialog from './views-history-dialog.vue';
 import TopCountriesDialog from './top-countries-dialog.vue';
 import EditLinkDialog from './edit-link-dialog.vue';
 import DeleteLinkDialog from './delete-link-dialog.vue';
+import BannedUaDialog from './banned-ua-dialog.vue';
 import QrCodeDialog from './qr-code-dialog.vue';
 import { useMetaExtractor } from '../../composables/use-meta-extractor';
 import { useShortLinkViewsSubscription } from '../../composables/use-short-link-views-subscription';
@@ -71,6 +72,7 @@ const showViewsDialog = ref(false);
 const showTopCountriesDialog = ref(false);
 const showEditDialog = ref(false);
 const showDeleteDialog = ref(false);
+const showBannedUaDialog = ref(false);
 
 const emit = defineEmits<{
 	(e: "updated"): void;
@@ -176,6 +178,13 @@ watch(
 							title="Edit link"
 						>
 							<Icon name="lucide:pencil" class="w-3.5 h-3.5" />
+						</button>
+						<button
+							@click="showBannedUaDialog = true"
+							class="flex-none p-1.5 rounded-lg border border-[hsl(240,11%,25%)] hover:border-[hsl(240,11%,40%)] bg-[hsl(240,11%,20%)] hover:bg-[hsl(240,11%,30%)] transition-colors"
+							title="Banned user agents"
+						>
+							<Icon name="lucide:shield-ban" class="w-3.5 h-3.5" />
 						</button>
 						<button
 							@click="showDeleteDialog = true"
@@ -298,6 +307,15 @@ watch(
 				:link-id="link.id"
 				:short-url="displayShortUrl"
 				@deleted="emit('deleted')"
+			/>
+		</ClientOnly>
+
+		<!-- Banned User Agents Dialog -->
+		<ClientOnly>
+			<BannedUaDialog
+				v-model:open="showBannedUaDialog"
+				:link-id="link.id"
+				:short-url="displayShortUrl"
 			/>
 		</ClientOnly>
 	</div>

--- a/web/layers/url-shortener/components/url-shortener/section.vue
+++ b/web/layers/url-shortener/components/url-shortener/section.vue
@@ -9,6 +9,7 @@ import FormShortHistory from '#layers/url-shortener/components/url-shortener/for
 			<UrlShortenerForm />
 			<FormShortHistory />
 			<UrlShortenerCustomDomainPanel />
+			<UrlShortenerBannedUaPresetsPanel />
 		</div>
 	</div>
 </template>

--- a/web/layers/url-shortener/composables/use-url-shortener.ts
+++ b/web/layers/url-shortener/composables/use-url-shortener.ts
@@ -1,4 +1,13 @@
-import type { CustomDomainOutputDto, ErrorModel, LinkBannedUserAgentDto, LinkOutputDto, ShortUrlProfileParamsSortByEnum } from '@twir/api/openapi'
+import type {
+	CustomDomainOutputDto,
+	ErrorModel,
+	LinkBannedUserAgentDto,
+	LinkOutputDto,
+	LinkPresetDto,
+	PresetDto,
+	PresetPatternDto,
+	ShortUrlProfileParamsSortByEnum,
+} from '@twir/api/openapi'
 
 import { useOapi } from '~/composables/use-oapi'
 
@@ -10,6 +19,14 @@ export const useUrlShortener = defineStore('url-shortener', () => {
 
 	const perLinkBannedUserAgents = ref<Map<string, LinkBannedUserAgentDto[]>>(new Map())
 	const isPerLinkBannedUserAgentsLoading = ref<Map<string, boolean>>(new Map())
+
+	const bannedUaPresets = ref<PresetDto[]>([])
+	const isBannedUaPresetsLoading = ref(false)
+	const presetPatterns = ref<Map<string, PresetPatternDto[]>>(new Map())
+	const isPresetPatternsLoading = ref<Map<string, boolean>>(new Map())
+
+	const linkPresets = ref<Map<string, LinkPresetDto[]>>(new Map())
+	const isLinkPresetsLoading = ref<Map<string, boolean>>(new Map())
 
 	async function shortUrl(opts: { url: string; alias?: string; useCustomDomain?: boolean }) {
 		try {
@@ -179,6 +196,151 @@ export const useUrlShortener = defineStore('url-shortener', () => {
 		}
 	}
 
+	async function fetchBannedUaPresets() {
+		isBannedUaPresetsLoading.value = true
+		try {
+			const response = await api.v1.shortLinksListPresets()
+			bannedUaPresets.value = response.data.data
+			return { data: response.data, error: response.error }
+		} catch (e) {
+			return { data: null, error: await parseApiError(e) }
+		} finally {
+			isBannedUaPresetsLoading.value = false
+		}
+	}
+
+	async function createBannedUaPreset(opts: { name: string; description?: string | null }) {
+		try {
+			const response = await api.v1.shortLinksCreatePreset({
+				name: opts.name,
+				description: opts.description ?? undefined,
+			})
+			bannedUaPresets.value = [...bannedUaPresets.value, response.data.data]
+			return { data: response.data, error: response.error }
+		} catch (e) {
+			return { data: null, error: await parseApiError(e) }
+		}
+	}
+
+	async function updateBannedUaPreset(
+		presetId: string,
+		opts: { name?: string; description?: string | null }
+	) {
+		try {
+			const response = await api.v1.shortLinksUpdatePreset(presetId, {
+				name: opts.name,
+				description: opts.description ?? undefined,
+			})
+			bannedUaPresets.value = bannedUaPresets.value.map((preset) =>
+				preset.id === presetId ? response.data.data : preset
+			)
+			return { data: response.data, error: response.error }
+		} catch (e) {
+			return { data: null, error: await parseApiError(e) }
+		}
+	}
+
+	async function deleteBannedUaPreset(presetId: string) {
+		try {
+			const response = await api.v1.shortLinksDeletePreset(presetId)
+			bannedUaPresets.value = bannedUaPresets.value.filter((preset) => preset.id !== presetId)
+			presetPatterns.value.delete(presetId)
+			for (const [linkId, presets] of linkPresets.value) {
+				linkPresets.value.set(
+					linkId,
+					presets.filter((item) => item.preset_id !== presetId)
+				)
+			}
+			return { data: response.data, error: response.error }
+		} catch (e) {
+			return { data: null, error: await parseApiError(e) }
+		}
+	}
+
+	async function fetchPresetPatterns(presetId: string) {
+		isPresetPatternsLoading.value.set(presetId, true)
+		try {
+			const response = await api.v1.shortLinksListPresetPatterns(presetId)
+			presetPatterns.value.set(presetId, response.data.data)
+			return { data: response.data, error: response.error }
+		} catch (e) {
+			return { data: null, error: await parseApiError(e) }
+		} finally {
+			isPresetPatternsLoading.value.set(presetId, false)
+		}
+	}
+
+	async function createPresetPattern(
+		presetId: string,
+		opts: { pattern: string; description?: string | null }
+	) {
+		try {
+			const response = await api.v1.shortLinksCreatePresetPattern(presetId, {
+				pattern: opts.pattern,
+				description: opts.description ?? undefined,
+			})
+			const current = presetPatterns.value.get(presetId) || []
+			presetPatterns.value.set(presetId, [...current, response.data.data])
+			return { data: response.data, error: response.error }
+		} catch (e) {
+			return { data: null, error: await parseApiError(e) }
+		}
+	}
+
+	async function deletePresetPattern(presetId: string, patternId: string) {
+		try {
+			const response = await api.v1.shortLinksDeletePresetPattern(presetId, patternId)
+			const current = presetPatterns.value.get(presetId) || []
+			presetPatterns.value.set(
+				presetId,
+				current.filter((item) => item.id !== patternId)
+			)
+			return { data: response.data, error: response.error }
+		} catch (e) {
+			return { data: null, error: await parseApiError(e) }
+		}
+	}
+
+	async function fetchLinkPresets(linkId: string) {
+		isLinkPresetsLoading.value.set(linkId, true)
+		try {
+			const response = await api.v1.shortLinksListLinkPresets(linkId)
+			linkPresets.value.set(linkId, response.data.data)
+			return { data: response.data, error: response.error }
+		} catch (e) {
+			return { data: null, error: await parseApiError(e) }
+		} finally {
+			isLinkPresetsLoading.value.set(linkId, false)
+		}
+	}
+
+	async function applyPresetToLink(linkId: string, presetId: string) {
+		try {
+			const response = await api.v1.shortLinksApplyPresetToLink(linkId, {
+				preset_id: presetId,
+			})
+			const current = linkPresets.value.get(linkId) || []
+			linkPresets.value.set(linkId, [...current, response.data.data])
+			return { data: response.data, error: response.error }
+		} catch (e) {
+			return { data: null, error: await parseApiError(e) }
+		}
+	}
+
+	async function removePresetFromLink(linkId: string, presetId: string) {
+		try {
+			const response = await api.v1.shortLinksRemovePresetFromLink(linkId, presetId)
+			const current = linkPresets.value.get(linkId) || []
+			linkPresets.value.set(
+				linkId,
+				current.filter((item) => item.preset_id !== presetId)
+			)
+			return { data: response.data, error: response.error }
+		} catch (e) {
+			return { data: null, error: await parseApiError(e) }
+		}
+	}
+
 	return {
 		shortUrl,
 		refetchLatestShortenedUrls,
@@ -194,6 +356,22 @@ export const useUrlShortener = defineStore('url-shortener', () => {
 		fetchPerLinkBannedUserAgents,
 		createPerLinkBannedUserAgent,
 		deletePerLinkBannedUserAgent,
+		bannedUaPresets,
+		isBannedUaPresetsLoading,
+		presetPatterns,
+		isPresetPatternsLoading,
+		fetchBannedUaPresets,
+		createBannedUaPreset,
+		updateBannedUaPreset,
+		deleteBannedUaPreset,
+		fetchPresetPatterns,
+		createPresetPattern,
+		deletePresetPattern,
+		linkPresets,
+		isLinkPresetsLoading,
+		fetchLinkPresets,
+		applyPresetToLink,
+		removePresetFromLink,
 	}
 })
 


### PR DESCRIPTION
## Summary

Restores the banned user agents UI for the URL shortener that was accidentally dropped in b54feb432 (#1045), and extends it to the preset-based API that landed in #983.

Backend (huma routes, pgx repositories, migrations) and the typed OpenAPI client were intact — only the frontend was missing. DB tables (`short_links_banned_ua_presets`, `short_links_banned_ua_preset_patterns`, `short_links_link_presets`, `short_links_link_banned_user_agents`) exist and are migrated.

## Changes

- **`banned-ua-presets-panel.vue`** (new) — collapsible panel on the shortener page: list/create presets (name + description), inline-edit preset name/description, delete preset via `ActionConfirm`, and per-preset regex pattern list/add/delete with client-side regex validation.
- **`banned-ua-dialog.vue`** (new) — per-link dialog opened from a shield button on each link card: apply/remove presets for the link (select of not-yet-applied presets) and manage per-link banned UA patterns (list/create/delete).
- **`use-url-shortener.ts`** — store functions for presets CRUD, preset patterns CRUD, and link-preset apply/remove using the existing typed `@twir/api/openapi` client (`shortLinksListPresets`, `shortLinksCreatePreset`, `shortLinksUpdatePreset`, `shortLinksDeletePreset`, `shortLinksListPresetPatterns`, `shortLinksCreatePresetPattern`, `shortLinksDeletePresetPattern`, `shortLinksListLinkPresets`, `shortLinksApplyPresetToLink`, `shortLinksRemovePresetFromLink`).
- **`section.vue`** — panel wired after the custom domain panel; **`link-card-with-stats.vue`** — shield-ban button + dialog.

## Verification

- `bunx oxlint web/layers/url-shortener` — 0 warnings, 0 errors (28 files)
- `nuxi typecheck` — no errors in `layers/url-shortener` (remaining errors are pre-existing in `landing`/`pastebin` layers)

## Notes

- The old deleted panel called `/v1/short-links/banned-user-agents` (global patterns), which no longer exists in the backend — the restored UI is built on the preset API instead.
- Per-link banned UA store functions existed but were unused; they are now wired into the new dialog.