### PR TITLE
fix(parser): wrong queue position for new song requests

### DIFF
--- a/apps/parser/internal/commands/songrequest/youtube/sr.go
+++ b/apps/parser/internal/commands/songrequest/youtube/sr.go
@@ -120,27 +120,15 @@ var SrCommand = &types.DefaultCommand{
 			return result, nil
 		}
 
-		latestSong := &model.RequestedSong{}
-
-		err = parseCtx.Services.Gorm.WithContext(ctx).
-			Where(`"channelId" = ?::uuid AND "deletedAt" IS NULL`, parseCtx.Channel.DBChannelID).
-			Order(`"createdAt" desc`).
-			Find(&latestSong).Error
-		if err != nil {
-			return nil, &types.CommandHandlerError{
-				Message: i18n.GetCtx(ctx, locales.Translations.Commands.Songrequest.Errors.GetLatestSong),
-				Err:     err,
-			}
-		}
-
 		requested := make([]*model.RequestedSong, 0, len(req.Data.Songs))
 		errors := make([]*ReqError, 0, len(req.Data.Songs))
 
-		var currentQueueCount int64
+		var maxQueuePosition int
 		err = parseCtx.Services.Gorm.WithContext(ctx).
-			Where(`"channelId" = ?::uuid AND "deletedAt" IS NULL`, parseCtx.Channel.DBChannelID).
 			Model(&model.RequestedSong{}).
-			Count(&currentQueueCount).
+			Where(`"channelId" = ?::uuid AND "deletedAt" IS NULL`, parseCtx.Channel.DBChannelID).
+			Select(`COALESCE(MAX("queuePosition"), 0)`).
+			Scan(&maxQueuePosition).
 			Error
 
 		if err != nil {
@@ -150,7 +138,7 @@ var SrCommand = &types.DefaultCommand{
 			}
 		}
 
-		for i, song := range req.Data.Songs {
+		for _, song := range req.Data.Songs {
 			err = validate(
 				ctx,
 				parseCtx.Services,
@@ -179,9 +167,9 @@ var SrCommand = &types.DefaultCommand{
 					VideoID:              song.Id,
 					Title:                song.Title,
 					Duration:             int32(song.Duration),
-					CreatedAt:            time.Now().UTC(),
-					QueuePosition:        int(currentQueueCount) + (i + 1),
-					SongLink:             null.StringFromPtr(song.Link),
+				CreatedAt:            time.Now().UTC(),
+				QueuePosition:        maxQueuePosition + len(requested) + 1,
+				SongLink:             null.StringFromPtr(song.Link),
 				}
 
 				err = parseCtx.Services.Gorm.WithContext(ctx).Create(model).Error


### PR DESCRIPTION
## Problem

Sometimes a song requested via `!sr` lands in the middle of the queue — or even at the very beginning — instead of the end.

## Root cause

In `apps/parser/internal/commands/songrequest/youtube/sr.go` the position was computed as:

```go
QueuePosition: int(currentQueueCount) + (i + 1)
```

where `currentQueueCount` is `COUNT(*)` of non-deleted songs. But songs leave the queue via **soft delete** (voteskip, dashboard skip/delete/clear in `apps/api-gql/internal/services/song_requests`), and the remaining songs keep their original `queuePosition` — they are never shifted.

Example: queue has positions 1–5, the first song is skipped → 4 rows remain, positions 2–5. A new `!sr` gets position 4+1=**5**, colliding with an existing song. Worse: if only a song with position 10 remains (count=1), the new song gets position **2** and sorts to the very top. Both `GetQueue`/`GetPublicQueue` in api-gql and the overlays/widgets sort by `queuePosition asc`, so the wrong position propagates everywhere. Frontend just renders what it gets — the bug is fully in the parser.

## Fix

- Compute the next position from `COALESCE(MAX("queuePosition"), 0)` instead of `COUNT(*)` — always strictly after the current tail.
- Assign positions per *successfully added* song (`max + len(requested) + 1`) instead of the search-result index, so partially-failing batch requests don't leave gaps.
- Removed the dead `latestSong` query (its result was never used).

Positions still restart from 1 after the queue is fully cleared, since only non-deleted rows are considered.

## Remaining note

Two truly concurrent `!sr` executions can still read the same MAX and collide — that requires row locking / serializable tx and is a much rarer race; out of scope here.

## Verification

- `go build ./...` and `go vet` in `apps/parser` — clean.