### PR TITLE
feat(parser): reply to $(touser) target's latest message like Fossabot

### DIFF
--- a/apps/parser/internal/commands-bus/commands-bus.go
+++ b/apps/parser/internal/commands-bus/commands-bus.go
@@ -20,6 +20,7 @@ import (
 	"github.com/twirapp/twir/libs/bus-core/parser"
 	platformentity "github.com/twirapp/twir/libs/entities/platform"
 	channelscommandsprefixrepository "github.com/twirapp/twir/libs/repositories/channels_commands_prefix"
+	chatmessagesrepository "github.com/twirapp/twir/libs/repositories/chat_messages"
 	"github.com/twirapp/twir/libs/repositories/streams"
 	streamsmodel "github.com/twirapp/twir/libs/repositories/streams/model"
 	"github.com/twirapp/twir/libs/repositories/userswithstats"
@@ -125,6 +126,44 @@ func (c *CommandsBus) enrichChatMessage(
 		UserStats:     userWithStats.Stats,
 		CommandPrefix: commandsPrefix,
 	}, nil
+}
+
+func (c *CommandsBus) findLatestMessageIdForReply(
+	ctx context.Context,
+	data generic.ChatMessage,
+	messagePlatform platformentity.Platform,
+	userLogin string,
+) string {
+	platformChannelID := data.PlatformChannelID
+	if platformChannelID == "" {
+		platformChannelID = data.BroadcasterUserId
+	}
+	if platformChannelID == "" {
+		return ""
+	}
+
+	latestMessage, err := c.services.ChatMessagesRepo.GetLatestByUser(
+		ctx,
+		chatmessagesrepository.GetLatestByUserInput{
+			Platform:          string(messagePlatform),
+			PlatformChannelID: platformChannelID,
+			UserName:          userLogin,
+		},
+	)
+	if err != nil {
+		if !errors.Is(err, chatmessagesrepository.ErrNotFound) {
+			c.services.Logger.Error(
+				"cannot find latest chat message for touser reply",
+				zap.Error(err),
+				zap.String("channel_id", platformChannelID),
+				zap.String("user_login", userLogin),
+			)
+		}
+
+		return ""
+	}
+
+	return latestMessage.ID.String()
 }
 
 func (c *CommandsBus) Subscribe() error {
@@ -294,14 +333,17 @@ func (c *CommandsBus) Subscribe() error {
 				return struct{}{}, nil
 			}
 
-			var replyTo string
-			if res.IsReply {
-				replyTo = data.MessageID
-			}
-
 			messagePlatform := platformentity.Platform(data.Platform)
 			if messagePlatform == "" {
 				messagePlatform = platformentity.PlatformTwitch
+			}
+
+			var replyTo string
+			if res.ReplyToUserLogin != "" {
+				replyTo = c.findLatestMessageIdForReply(ctx, data, messagePlatform, res.ReplyToUserLogin)
+			}
+			if replyTo == "" && res.IsReply {
+				replyTo = data.MessageID
 			}
 
 			for _, r := range res.Responses {

--- a/apps/parser/internal/commands/commands.go
+++ b/apps/parser/internal/commands/commands.go
@@ -45,6 +45,7 @@ import (
 	"github.com/twirapp/twir/apps/parser/internal/types"
 	"github.com/twirapp/twir/apps/parser/internal/types/services"
 	"github.com/twirapp/twir/apps/parser/internal/variables"
+	"github.com/twirapp/twir/apps/parser/internal/variables/to_user"
 	"github.com/twirapp/twir/apps/parser/locales"
 	"github.com/twirapp/twir/libs/bus-core/events"
 	"github.com/twirapp/twir/libs/bus-core/generic"
@@ -242,6 +243,17 @@ func (c *Commands) FindChannelCommandInInput(
 	}
 
 	return &res
+}
+
+func responseUsesVariable(text, variableName string) bool {
+	for _, match := range variables.Regexp.FindAllStringSubmatch(text, -1) {
+		name, _, _ := strings.Cut(match[1], " ")
+		if name == variableName {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (c *Commands) ParseCommandResponses(
@@ -491,6 +503,21 @@ func (c *Commands) ParseCommandResponses(
 				return *r.Text
 			},
 		)
+	}
+
+	if len(mentions) > 0 {
+		for _, r := range result.Responses {
+			if !responseUsesVariable(r, to_user.ToUser.Name) {
+				continue
+			}
+
+			result.ReplyToUserLogin = mentions[0].UserLogin
+			if result.ReplyToUserLogin == "" {
+				result.ReplyToUserLogin = mentions[0].UserName
+			}
+
+			break
+		}
 	}
 
 	wg := &sync.WaitGroup{}

--- a/libs/bus-core/parser/commands.go
+++ b/libs/bus-core/parser/commands.go
@@ -11,6 +11,7 @@ type CommandParseResponse struct {
 	IsReply           bool
 	KeepOrder         bool
 	SkipToxicityCheck bool
+	ReplyToUserLogin  string
 }
 
 type ParseVariablesInTextRequest struct {

--- a/libs/repositories/chat_messages/chat_messages.go
+++ b/libs/repositories/chat_messages/chat_messages.go
@@ -11,6 +11,10 @@ type Repository interface {
 	Create(ctx context.Context, input CreateInput) error
 	CreateMany(ctx context.Context, input []CreateInput) error
 	GetMany(ctx context.Context, input GetManyInput) ([]model.ChatMessage, error)
+	GetLatestByUser(
+		ctx context.Context,
+		input GetLatestByUserInput,
+	) (model.ChatMessage, error)
 }
 
 type PlatformChannelIdentity struct {
@@ -19,14 +23,14 @@ type PlatformChannelIdentity struct {
 }
 
 type CreateInput struct {
-	ID              string
-	Platform        string
+	ID                string
+	Platform          string
 	PlatformChannelID string
-	UserID          string
-	Text            string
-	UserName        string
-	UserDisplayName string
-	UserColor       string
+	UserID            string
+	Text              string
+	UserName          string
+	UserDisplayName   string
+	UserColor         string
 }
 
 type GetManyInput struct {
@@ -36,9 +40,15 @@ type GetManyInput struct {
 	ChannelPairs      []PlatformChannelIdentity
 	Platform          *string
 	PlatformChannelID *string
-	UserNameLike *string
-	TextLike     *string
-	UserIDs      []string
+	UserNameLike      *string
+	TextLike          *string
+	UserIDs           []string
 
 	TimeGte *time.Time
+}
+
+type GetLatestByUserInput struct {
+	Platform          string
+	PlatformChannelID string
+	UserName          string
 }

--- a/libs/repositories/chat_messages/datasources/clickhouse/clickhouse.go
+++ b/libs/repositories/chat_messages/datasources/clickhouse/clickhouse.go
@@ -117,6 +117,60 @@ func (c *Clickhouse) createBatch(ctx context.Context, input []chat_messages.Crea
 	return nil
 }
 
+func (c *Clickhouse) GetLatestByUser(
+	ctx context.Context,
+	input chat_messages.GetLatestByUserInput,
+) (model.ChatMessage, error) {
+	query, args, err := sq.Select(
+		"id",
+		"platform",
+		"platform_channel_id",
+		"user_id",
+		"user_name",
+		"user_display_name",
+		"user_color",
+		"text",
+		"created_at",
+	).
+		From("chat_messages").
+		Where(squirrel.Eq{"platform": input.Platform}).
+		Where(squirrel.Eq{"platform_channel_id": input.PlatformChannelID}).
+		Where("lower(user_name) = lower(?)", input.UserName).
+		OrderBy("created_at DESC", "id DESC").
+		Limit(1).
+		ToSql()
+	if err != nil {
+		return model.ChatMessage{}, fmt.Errorf("failed to build query: %w", err)
+	}
+
+	rows, err := c.client.Query(ctx, query, args...)
+	if err != nil {
+		return model.ChatMessage{}, fmt.Errorf("failed to query: %w", err)
+	}
+	defer rows.Close()
+
+	if !rows.Next() {
+		return model.ChatMessage{}, chat_messages.ErrNotFound
+	}
+
+	var m model.ChatMessage
+	if err := rows.Scan(
+		&m.ID,
+		&m.Platform,
+		&m.ChannelID,
+		&m.UserID,
+		&m.UserName,
+		&m.UserDisplayName,
+		&m.UserColor,
+		&m.Text,
+		&m.CreatedAt,
+	); err != nil {
+		return model.ChatMessage{}, fmt.Errorf("failed to scan: %w", err)
+	}
+
+	return m, nil
+}
+
 func (c *Clickhouse) GetMany(
 	ctx context.Context,
 	input chat_messages.GetManyInput,

--- a/libs/repositories/chat_messages/datasources/postgres/pgx.go
+++ b/libs/repositories/chat_messages/datasources/postgres/pgx.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/Masterminds/squirrel"
@@ -33,6 +34,48 @@ var sq = squirrel.StatementBuilder.PlaceholderFormat(squirrel.Dollar)
 type Pgx struct {
 	pool   *pgxpool.Pool
 	getter *trmpgx.CtxGetter
+}
+
+func (c *Pgx) GetLatestByUser(
+	ctx context.Context,
+	input chat_messages.GetLatestByUserInput,
+) (model.ChatMessage, error) {
+	query, args, err := sq.Select(
+		"id",
+		"channel_id",
+		"user_id",
+		"user_name",
+		"user_display_name",
+		"user_color",
+		"text",
+		"created_at",
+		"updated_at",
+	).
+		From("chat_messages").
+		Where(squirrel.Expr("channel_id::text = ?::text", input.PlatformChannelID)).
+		Where("lower(user_name) = lower(?)", input.UserName).
+		OrderBy("created_at DESC", "id DESC").
+		Limit(1).
+		ToSql()
+	if err != nil {
+		return model.ChatMessage{}, fmt.Errorf("failed to build query: %w", err)
+	}
+
+	conn := c.getter.DefaultTrOrDB(ctx, c.pool)
+	rows, err := conn.Query(ctx, query, args...)
+	if err != nil {
+		return model.ChatMessage{}, fmt.Errorf("failed to execute query: %w", err)
+	}
+
+	m, err := pgx.CollectExactlyOneRow(rows, pgx.RowToStructByName[model.ChatMessage])
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return model.ChatMessage{}, chat_messages.ErrNotFound
+		}
+		return model.ChatMessage{}, fmt.Errorf("failed to collect row: %w", err)
+	}
+
+	return m, nil
 }
 
 func (c *Pgx) GetMany(ctx context.Context, input chat_messages.GetManyInput) (

--- a/libs/repositories/chat_messages/errors.go
+++ b/libs/repositories/chat_messages/errors.go
@@ -1,0 +1,5 @@
+package chat_messages
+
+import "errors"
+
+var ErrNotFound = errors.New("chat message not found")


### PR DESCRIPTION
Closes #1049

## What

When a custom command response uses the `$(touser)` variable with a `@mention`, Twir now sends the response as a **native Twitch reply** to the mentioned user's latest chat message instead of a plain message / reply to the command message.

Example flow:

```
cHATTERwithQuestion: How do I do something?
moderator1337: !questiontheme @cHATTERwithQuestion
TwirApp: (replying to "How do I do something?") This question was resolved like this: ...
```

## How

- `libs/repositories/chat_messages` — new `GetLatestByUser` repository method (ClickHouse + Postgres implementations): exact case-insensitive `user_name` match in the given `platform`/`platform_channel_id`, ordered by `created_at DESC, id DESC`, `LIMIT 1`. Returns `ErrNotFound` when the user has no stored messages.
- `libs/bus-core/parser` — `CommandParseResponse` gains a `ReplyToUserLogin` field.
- `apps/parser/internal/commands` — when a raw command response text uses `$(touser)` and the triggering message has mentions, the first mention's login is recorded into `ReplyToUserLogin`.
- `apps/parser/internal/commands-bus` — on send, if `ReplyToUserLogin` is set, the latest stored message ID of that user is looked up in ClickHouse and used as `ReplyTo` (the existing send pipeline already maps it to Helix `ReplyParentMessageID`). If nothing is found, behavior falls back to the previous `IsReply` logic (reply to the command message or plain message).

## Acceptance criteria coverage

- Latest available message from `@username` is found (newest first, deterministic tie-break by id)
- Response is sent as a native Twitch reply referencing the correct Twitch message ID (ClickHouse `id` = Twitch message ID)
- Case-insensitive username matching (`lower(user_name) = lower(?)`)
- Messages from other users/channels are ignored
- Missing message IDs are handled gracefully (fallback, error logged for non-NotFound failures)

## Verification

- `go build` passes for `parser`, `bots`, `api-gql`, `eventsub`, `events`
- `go test ./internal/commands/ ./internal/commands-bus/` — 7 passed
- gofmt clean