### PR TITLE
fix(api-gql): apply banned user agents to short links correctly

### DIFF
--- a/apps/api-gql/internal/delivery/http/routes/shortlinks/link_banned_user_agents_create.go
+++ b/apps/api-gql/internal/delivery/http/routes/shortlinks/link_banned_user_agents_create.go
@@ -63,7 +63,8 @@ func (c *createLinkBannedUserAgent) Handler(
 		return nil, huma.NewError(http.StatusUnauthorized, "Unauthorized")
 	}
 
-	if _, err := resolveOwnedShortLink(ctx, c.service, c.customDomainsService, user.ID, input.LinkID); err != nil {
+	link, err := resolveOwnedShortLink(ctx, c.service, c.customDomainsService, user.ID, input.LinkID)
+	if err != nil {
 		switch {
 		case errors.Is(err, errShortLinkNotFound):
 			return nil, huma.NewError(http.StatusNotFound, "Link not found")
@@ -77,7 +78,7 @@ func (c *createLinkBannedUserAgent) Handler(
 	item, err := c.service.CreateLinkBannedUserAgent(
 		ctx,
 		shortlinkslinkbannedusaragentsrepository.CreateInput{
-			LinkID:      input.LinkID,
+			LinkID:      link.ID,
 			Pattern:     input.Body.Pattern,
 			Description: input.Body.Description,
 		},

--- a/apps/api-gql/internal/delivery/http/routes/shortlinks/link_banned_user_agents_delete.go
+++ b/apps/api-gql/internal/delivery/http/routes/shortlinks/link_banned_user_agents_delete.go
@@ -60,7 +60,8 @@ func (c *deleteLinkBannedUserAgent) Handler(
 		return nil, huma.NewError(http.StatusUnauthorized, "Unauthorized")
 	}
 
-	if _, err := resolveOwnedShortLink(ctx, c.service, c.customDomainsService, user.ID, input.LinkID); err != nil {
+	link, err := resolveOwnedShortLink(ctx, c.service, c.customDomainsService, user.ID, input.LinkID)
+	if err != nil {
 		switch {
 		case errors.Is(err, errShortLinkNotFound):
 			return nil, huma.NewError(http.StatusNotFound, "Link not found")
@@ -71,7 +72,7 @@ func (c *deleteLinkBannedUserAgent) Handler(
 		}
 	}
 
-	if err := c.service.DeleteLinkBannedUserAgent(ctx, input.ID, input.LinkID); err != nil {
+	if err := c.service.DeleteLinkBannedUserAgent(ctx, input.ID, link.ID); err != nil {
 		switch {
 		case errors.Is(err, shortlinkslinkbannedusaragentsrepository.ErrNotFound):
 			return nil, huma.NewError(http.StatusNotFound, "Banned user agent not found")

--- a/apps/api-gql/internal/delivery/http/routes/shortlinks/link_banned_user_agents_list.go
+++ b/apps/api-gql/internal/delivery/http/routes/shortlinks/link_banned_user_agents_list.go
@@ -67,7 +67,8 @@ func (c *listLinkBannedUserAgents) Handler(
 		return nil, huma.NewError(http.StatusUnauthorized, "Unauthorized")
 	}
 
-	if _, err := resolveOwnedShortLink(ctx, c.service, c.customDomainsService, user.ID, input.LinkID); err != nil {
+	link, err := resolveOwnedShortLink(ctx, c.service, c.customDomainsService, user.ID, input.LinkID)
+	if err != nil {
 		switch {
 		case errors.Is(err, errShortLinkNotFound):
 			return nil, huma.NewError(http.StatusNotFound, "Link not found")
@@ -78,7 +79,7 @@ func (c *listLinkBannedUserAgents) Handler(
 		}
 	}
 
-	items, err := c.service.GetLinkBannedUserAgents(ctx, input.LinkID)
+	items, err := c.service.GetLinkBannedUserAgents(ctx, link.ID)
 	if err != nil {
 		return nil, huma.NewError(http.StatusInternalServerError, "Cannot get banned user agents", err)
 	}

--- a/apps/api-gql/internal/delivery/http/routes/shortlinks/link_presets.go
+++ b/apps/api-gql/internal/delivery/http/routes/shortlinks/link_presets.go
@@ -67,7 +67,8 @@ func (c *listLinkPresets) Handler(
 		return nil, huma.NewError(http.StatusUnauthorized, "Unauthorized")
 	}
 
-	if _, err := resolveOwnedShortLink(ctx, c.service, c.customDomainsService, user.ID, input.LinkID); err != nil {
+	link, err := resolveOwnedShortLink(ctx, c.service, c.customDomainsService, user.ID, input.LinkID)
+	if err != nil {
 		switch {
 		case errors.Is(err, errShortLinkNotFound):
 			return nil, huma.NewError(http.StatusNotFound, "Link not found")
@@ -78,7 +79,7 @@ func (c *listLinkPresets) Handler(
 		}
 	}
 
-	items, err := c.service.GetLinkPresets(ctx, input.LinkID)
+	items, err := c.service.GetLinkPresets(ctx, link.ID)
 	if err != nil {
 		return nil, huma.NewError(http.StatusInternalServerError, "Cannot get link presets", err)
 	}
@@ -149,7 +150,8 @@ func (c *applyPresetToLink) Handler(
 		return nil, huma.NewError(http.StatusUnauthorized, "Unauthorized")
 	}
 
-	if _, err := resolveOwnedShortLink(ctx, c.service, c.customDomainsService, user.ID, input.LinkID); err != nil {
+	link, err := resolveOwnedShortLink(ctx, c.service, c.customDomainsService, user.ID, input.LinkID)
+	if err != nil {
 		switch {
 		case errors.Is(err, errShortLinkNotFound):
 			return nil, huma.NewError(http.StatusNotFound, "Link not found")
@@ -172,7 +174,7 @@ func (c *applyPresetToLink) Handler(
 	item, err := c.service.ApplyPresetToLink(
 		ctx,
 		shortlinkslinkpresetsrepository.CreateInput{
-			LinkID:   input.LinkID,
+			LinkID:   link.ID,
 			PresetID: input.Body.PresetID,
 		},
 	)
@@ -244,7 +246,8 @@ func (c *removePresetFromLink) Handler(
 		return nil, huma.NewError(http.StatusUnauthorized, "Unauthorized")
 	}
 
-	if _, err := resolveOwnedShortLink(ctx, c.service, c.customDomainsService, user.ID, input.LinkID); err != nil {
+	link, err := resolveOwnedShortLink(ctx, c.service, c.customDomainsService, user.ID, input.LinkID)
+	if err != nil {
 		switch {
 		case errors.Is(err, errShortLinkNotFound):
 			return nil, huma.NewError(http.StatusNotFound, "Link not found")
@@ -255,7 +258,7 @@ func (c *removePresetFromLink) Handler(
 		}
 	}
 
-	if err := c.service.RemovePresetFromLink(ctx, input.LinkID, input.PresetID); err != nil {
+	if err := c.service.RemovePresetFromLink(ctx, link.ID, input.PresetID); err != nil {
 		return nil, huma.NewError(http.StatusInternalServerError, "Cannot remove preset from link", err)
 	}
 

--- a/apps/api-gql/internal/delivery/mcp/tools_data.go
+++ b/apps/api-gql/internal/delivery/mcp/tools_data.go
@@ -12,6 +12,7 @@ import (
 	"github.com/twirapp/twir/apps/api-gql/internal/services/pastebins"
 	"github.com/twirapp/twir/apps/api-gql/internal/services/shortenedurls"
 	shortlinksua "github.com/twirapp/twir/libs/repositories/short_links_link_banned_user_agents"
+	"github.com/twirapp/twir/libs/repositories/shortened_urls/model"
 )
 
 type secretOutput struct {
@@ -227,16 +228,16 @@ type deleteBannedUAInput struct {
 	BannedUserAgentID string `json:"bannedUserAgentId"`
 }
 
-func (h *Handler) ownedShortURL(ctx context.Context, requestScope scope, id string) error {
+func (h *Handler) ownedShortURL(ctx context.Context, requestScope scope, id string) (model.ShortenedUrl, error) {
 	item, err := h.deps.ShortURLs.GetByShortID(ctx, nil, id)
 	if err != nil {
-		return err
+		return model.Nil, err
 	}
 	owner := ownerID(requestScope)
 	if item.IsNil() || item.CreatedByUserId == nil || *item.CreatedByUserId != owner {
-		return errors.New("short URL not found")
+		return model.Nil, errors.New("short URL not found")
 	}
-	return nil
+	return item, nil
 }
 
 func (h *Handler) addShortURLTools(s *modelsdk.Server, requestScope scope) {
@@ -253,7 +254,7 @@ func (h *Handler) addShortURLTools(s *modelsdk.Server, requestScope scope) {
 		return nil, item, err
 	})
 	addTool(newToolRegistrar(s, requestScope.AccessScopes), &modelsdk.Tool{Name: "get_short_url", Description: "Get one owned short URL."}, func(ctx context.Context, _ *modelsdk.CallToolRequest, input idInput) (*modelsdk.CallToolResult, any, error) {
-		if err := h.ownedShortURL(ctx, requestScope, input.ID); err != nil {
+		if _, err := h.ownedShortURL(ctx, requestScope, input.ID); err != nil {
 			return nil, nil, err
 		}
 		item, err := h.deps.ShortURLs.GetByShortID(ctx, nil, input.ID)
@@ -262,21 +263,21 @@ func (h *Handler) addShortURLTools(s *modelsdk.Server, requestScope scope) {
 	addTool(newToolRegistrar(s, requestScope.AccessScopes), &modelsdk.Tool{Name: "list_short_urls", Description: "List short URLs owned by this channel owner."}, listShortURLs)
 	addTool(newToolRegistrar(s, requestScope.AccessScopes), &modelsdk.Tool{Name: "list_short_links", Description: "List short links owned by this channel owner."}, listShortURLs)
 	addTool(newToolRegistrar(s, requestScope.AccessScopes), &modelsdk.Tool{Name: "update_short_url", Description: "Update an owned short URL."}, func(ctx context.Context, _ *modelsdk.CallToolRequest, input updateShortURLInput) (*modelsdk.CallToolResult, any, error) {
-		if err := h.ownedShortURL(ctx, requestScope, input.ID); err != nil {
+		if _, err := h.ownedShortURL(ctx, requestScope, input.ID); err != nil {
 			return nil, nil, err
 		}
 		item, err := h.deps.ShortURLs.Update(ctx, nil, input.ID, shortenedurls.UpdateInput{URL: input.URL, ShortID: input.Alias})
 		return nil, item, err
 	})
 	addTool(newToolRegistrar(s, requestScope.AccessScopes), &modelsdk.Tool{Name: "delete_short_url", Description: "Delete an owned short URL."}, func(ctx context.Context, _ *modelsdk.CallToolRequest, input idInput) (*modelsdk.CallToolResult, any, error) {
-		if err := h.ownedShortURL(ctx, requestScope, input.ID); err != nil {
+		if _, err := h.ownedShortURL(ctx, requestScope, input.ID); err != nil {
 			return nil, nil, err
 		}
 		err := h.deps.ShortURLs.Delete(ctx, nil, input.ID)
 		return nil, map[string]bool{"deleted": err == nil}, err
 	})
 	addTool(newToolRegistrar(s, requestScope.AccessScopes), &modelsdk.Tool{Name: "get_short_url_stats", Description: "Get click statistics for an owned short URL."}, func(ctx context.Context, _ *modelsdk.CallToolRequest, input statsInput) (*modelsdk.CallToolResult, any, error) {
-		if err := h.ownedShortURL(ctx, requestScope, input.ID); err != nil {
+		if _, err := h.ownedShortURL(ctx, requestScope, input.ID); err != nil {
 			return nil, nil, err
 		}
 		if input.Interval == "" {
@@ -286,24 +287,27 @@ func (h *Handler) addShortURLTools(s *modelsdk.Server, requestScope scope) {
 		return nil, map[string]any{"points": points}, err
 	})
 	addTool(newToolRegistrar(s, requestScope.AccessScopes), &modelsdk.Tool{Name: "list_banned_user_agents", Description: "List user-agent patterns banned for an owned short URL."}, func(ctx context.Context, _ *modelsdk.CallToolRequest, input idInput) (*modelsdk.CallToolResult, any, error) {
-		if err := h.ownedShortURL(ctx, requestScope, input.ID); err != nil {
+		link, err := h.ownedShortURL(ctx, requestScope, input.ID)
+		if err != nil {
 			return nil, nil, err
 		}
-		items, err := h.deps.ShortURLs.GetLinkBannedUserAgents(ctx, input.ID)
+		items, err := h.deps.ShortURLs.GetLinkBannedUserAgents(ctx, link.ID)
 		return nil, map[string]any{"patterns": items}, err
 	})
 	addTool(newToolRegistrar(s, requestScope.AccessScopes), &modelsdk.Tool{Name: "ban_user_agent", Description: "Ban a user-agent pattern for an owned short URL."}, func(ctx context.Context, _ *modelsdk.CallToolRequest, input bannedUAInput) (*modelsdk.CallToolResult, any, error) {
-		if err := h.ownedShortURL(ctx, requestScope, input.ID); err != nil {
+		link, err := h.ownedShortURL(ctx, requestScope, input.ID)
+		if err != nil {
 			return nil, nil, err
 		}
-		item, err := h.deps.ShortURLs.CreateLinkBannedUserAgent(ctx, shortlinksua.CreateInput{LinkID: input.ID, Pattern: input.Pattern, Description: input.Description})
+		item, err := h.deps.ShortURLs.CreateLinkBannedUserAgent(ctx, shortlinksua.CreateInput{LinkID: link.ID, Pattern: input.Pattern, Description: input.Description})
 		return nil, item, err
 	})
 	addTool(newToolRegistrar(s, requestScope.AccessScopes), &modelsdk.Tool{Name: "unban_user_agent", Description: "Remove a user-agent ban from an owned short URL."}, func(ctx context.Context, _ *modelsdk.CallToolRequest, input deleteBannedUAInput) (*modelsdk.CallToolResult, any, error) {
-		if err := h.ownedShortURL(ctx, requestScope, input.ID); err != nil {
+		link, err := h.ownedShortURL(ctx, requestScope, input.ID)
+		if err != nil {
 			return nil, nil, err
 		}
-		err := h.deps.ShortURLs.DeleteLinkBannedUserAgent(ctx, input.BannedUserAgentID, input.ID)
+		err = h.deps.ShortURLs.DeleteLinkBannedUserAgent(ctx, input.BannedUserAgentID, link.ID)
 		return nil, map[string]bool{"deleted": err == nil}, err
 	})
 }

--- a/apps/api-gql/internal/services/shortenedurls/shortenedurls.go
+++ b/apps/api-gql/internal/services/shortenedurls/shortenedurls.go
@@ -650,6 +650,19 @@ func (c *Service) GetTopCountries(ctx context.Context, input GetTopCountriesInpu
 	return output, nil
 }
 
+// compileBannedUAPattern must stay the single compile path for both validation and matching.
+func compileBannedUAPattern(pattern string) (*regexp.Regexp, error) {
+	return regexp.Compile("(?i)" + pattern)
+}
+
+func matchBannedUAPattern(pattern, userAgent string) bool {
+	re, err := compileBannedUAPattern(pattern)
+	if err != nil {
+		return false
+	}
+	return re.MatchString(userAgent)
+}
+
 func (c *Service) IsUserAgentBanned(
 	ctx context.Context,
 	link model.ShortenedUrl,
@@ -659,25 +672,21 @@ func (c *Service) IsUserAgentBanned(
 		return false, nil
 	}
 
-	if link.ShortID != "" {
-		directPatterns, err := c.linkBannedUserAgentsRepository.GetByLinkID(ctx, link.ShortID)
+	if link.ID != "" {
+		directPatterns, err := c.linkBannedUserAgentsRepository.GetByLinkID(ctx, link.ID)
 		if err != nil {
 			return false, fmt.Errorf("failed to get direct link banned patterns: %w", err)
 		}
 
 		for _, p := range directPatterns {
-			re, err := regexp.Compile(p.Pattern)
-			if err != nil {
-				continue
-			}
-			if re.MatchString(userAgent) {
+			if matchBannedUAPattern(p.Pattern, userAgent) {
 				return true, nil
 			}
 		}
 	}
 
-	if link.ShortID != "" {
-		linkPresets, err := c.linkPresetsRepository.GetByLinkID(ctx, link.ShortID)
+	if link.ID != "" {
+		linkPresets, err := c.linkPresetsRepository.GetByLinkID(ctx, link.ID)
 		if err != nil {
 			return false, fmt.Errorf("failed to get link presets: %w", err)
 		}
@@ -689,11 +698,7 @@ func (c *Service) IsUserAgentBanned(
 			}
 
 			for _, p := range presetPatterns {
-				re, err := regexp.Compile(p.Pattern)
-				if err != nil {
-					continue
-				}
-				if re.MatchString(userAgent) {
+				if matchBannedUAPattern(p.Pattern, userAgent) {
 					return true, nil
 				}
 			}
@@ -741,7 +746,7 @@ func (c *Service) CreatePresetPattern(
 	ctx context.Context,
 	input shortlinksbanneduapresetpatternsrepository.CreateInput,
 ) (shortlinksbanneduapresetpatternsrepository.Pattern, error) {
-	if _, err := regexp.Compile(input.Pattern); err != nil {
+	if _, err := compileBannedUAPattern(input.Pattern); err != nil {
 		return shortlinksbanneduapresetpatternsrepository.Nil, fmt.Errorf("invalid regex pattern: %w", err)
 	}
 	return c.presetPatternsRepository.Create(ctx, input)
@@ -777,7 +782,7 @@ func (c *Service) CreateLinkBannedUserAgent(
 	ctx context.Context,
 	input shortlinkslinkbannedusaragentsrepository.CreateInput,
 ) (shortlinkslinkbannedusaragentsrepository.BannedUserAgent, error) {
-	if _, err := regexp.Compile(input.Pattern); err != nil {
+	if _, err := compileBannedUAPattern(input.Pattern); err != nil {
 		return shortlinkslinkbannedusaragentsrepository.Nil, fmt.Errorf("invalid regex pattern: %w", err)
 	}
 	return c.linkBannedUserAgentsRepository.Create(ctx, input)

--- a/apps/api-gql/internal/services/shortenedurls/shortenedurls_test.go
+++ b/apps/api-gql/internal/services/shortenedurls/shortenedurls_test.go
@@ -1,0 +1,269 @@
+package shortenedurls
+
+import (
+	"context"
+	"testing"
+
+	shortlinksbanneduapresetpatternsrepository "github.com/twirapp/twir/libs/repositories/short_links_banned_ua_preset_patterns"
+	shortlinkslinkbannedusaragentsrepository "github.com/twirapp/twir/libs/repositories/short_links_link_banned_user_agents"
+	shortlinkslinkpresetsrepository "github.com/twirapp/twir/libs/repositories/short_links_link_presets"
+	"github.com/twirapp/twir/libs/repositories/shortened_urls/model"
+)
+
+type linkBannedUserAgentsStub struct {
+	patterns         []shortlinkslinkbannedusaragentsrepository.BannedUserAgent
+	getByLinkIDCalls []string
+	createCalls      int
+}
+
+func (s *linkBannedUserAgentsStub) GetByLinkID(
+	_ context.Context,
+	linkID string,
+) ([]shortlinkslinkbannedusaragentsrepository.BannedUserAgent, error) {
+	s.getByLinkIDCalls = append(s.getByLinkIDCalls, linkID)
+	return s.patterns, nil
+}
+
+func (s *linkBannedUserAgentsStub) Create(
+	_ context.Context,
+	input shortlinkslinkbannedusaragentsrepository.CreateInput,
+) (shortlinkslinkbannedusaragentsrepository.BannedUserAgent, error) {
+	s.createCalls++
+	return shortlinkslinkbannedusaragentsrepository.BannedUserAgent{
+		ID:      "ban-id",
+		LinkID:  input.LinkID,
+		Pattern: input.Pattern,
+	}, nil
+}
+
+func (s *linkBannedUserAgentsStub) Delete(_ context.Context, _, _ string) error {
+	return nil
+}
+
+type linkPresetsStub struct {
+	presets          []shortlinkslinkpresetsrepository.LinkPreset
+	getByLinkIDCalls []string
+}
+
+func (s *linkPresetsStub) GetByLinkID(
+	_ context.Context,
+	linkID string,
+) ([]shortlinkslinkpresetsrepository.LinkPreset, error) {
+	s.getByLinkIDCalls = append(s.getByLinkIDCalls, linkID)
+	return s.presets, nil
+}
+
+func (s *linkPresetsStub) GetByPresetID(
+	_ context.Context,
+	_ string,
+) ([]shortlinkslinkpresetsrepository.LinkPreset, error) {
+	return nil, nil
+}
+
+func (s *linkPresetsStub) GetLinksByPresetID(_ context.Context, _ string) ([]string, error) {
+	return nil, nil
+}
+
+func (s *linkPresetsStub) Create(
+	_ context.Context,
+	_ shortlinkslinkpresetsrepository.CreateInput,
+) (shortlinkslinkpresetsrepository.LinkPreset, error) {
+	return shortlinkslinkpresetsrepository.LinkPreset{}, nil
+}
+
+func (s *linkPresetsStub) Delete(_ context.Context, _ string) error {
+	return nil
+}
+
+func (s *linkPresetsStub) DeleteByLinkAndPreset(_ context.Context, _, _ string) error {
+	return nil
+}
+
+type presetPatternsStub struct {
+	patternsByPreset map[string][]shortlinksbanneduapresetpatternsrepository.Pattern
+}
+
+func (s *presetPatternsStub) GetByPresetID(
+	_ context.Context,
+	presetID string,
+) ([]shortlinksbanneduapresetpatternsrepository.Pattern, error) {
+	return s.patternsByPreset[presetID], nil
+}
+
+func (s *presetPatternsStub) Create(
+	_ context.Context,
+	_ shortlinksbanneduapresetpatternsrepository.CreateInput,
+) (shortlinksbanneduapresetpatternsrepository.Pattern, error) {
+	return shortlinksbanneduapresetpatternsrepository.Pattern{}, nil
+}
+
+func (s *presetPatternsStub) Delete(_ context.Context, _, _ string) error {
+	return nil
+}
+
+func newBanCheckService(
+	direct *linkBannedUserAgentsStub,
+	linkPresets *linkPresetsStub,
+	presetPatterns *presetPatternsStub,
+) *Service {
+	return &Service{
+		linkBannedUserAgentsRepository: direct,
+		linkPresetsRepository:          linkPresets,
+		presetPatternsRepository:       presetPatterns,
+	}
+}
+
+func TestIsUserAgentBannedMatchesCaseInsensitive(t *testing.T) {
+	direct := &linkBannedUserAgentsStub{
+		patterns: []shortlinkslinkbannedusaragentsrepository.BannedUserAgent{
+			{Pattern: "chatterino.+|ffzbot.+"},
+		},
+	}
+	service := newBanCheckService(direct, &linkPresetsStub{}, &presetPatternsStub{})
+
+	banned, err := service.IsUserAgentBanned(
+		context.Background(),
+		model.ShortenedUrl{ID: "link-pk", ShortID: "onlyfans"},
+		"Chatterino/2.5.3 (https://chatterino.com)",
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !banned {
+		t.Fatal("expected mixed-case Chatterino user agent to be banned by lowercase pattern")
+	}
+}
+
+func TestIsUserAgentBannedUsesLinkPrimaryKey(t *testing.T) {
+	direct := &linkBannedUserAgentsStub{}
+	linkPresets := &linkPresetsStub{}
+	service := newBanCheckService(direct, linkPresets, &presetPatternsStub{})
+
+	link := model.ShortenedUrl{ID: "uuid-primary-key", ShortID: "h7Hs1"}
+	if _, err := service.IsUserAgentBanned(context.Background(), link, "Mozilla/5.0"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, got := range direct.getByLinkIDCalls {
+		if got != link.ID {
+			t.Fatalf("direct patterns lookup used %q, want link primary key %q", got, link.ID)
+		}
+	}
+	for _, got := range linkPresets.getByLinkIDCalls {
+		if got != link.ID {
+			t.Fatalf("link presets lookup used %q, want link primary key %q", got, link.ID)
+		}
+	}
+	if len(direct.getByLinkIDCalls) == 0 || len(linkPresets.getByLinkIDCalls) == 0 {
+		t.Fatal("expected both repositories to be queried")
+	}
+}
+
+func TestIsUserAgentBannedMatchesPresetPatterns(t *testing.T) {
+	linkPresets := &linkPresetsStub{
+		presets: []shortlinkslinkpresetsrepository.LinkPreset{
+			{LinkID: "link-pk", PresetID: "preset-1"},
+		},
+	}
+	presetPatterns := &presetPatternsStub{
+		patternsByPreset: map[string][]shortlinksbanneduapresetpatternsrepository.Pattern{
+			"preset-1": {{Pattern: "twitchlib"}},
+		},
+	}
+	service := newBanCheckService(&linkBannedUserAgentsStub{}, linkPresets, presetPatterns)
+
+	banned, err := service.IsUserAgentBanned(
+		context.Background(),
+		model.ShortenedUrl{ID: "link-pk", ShortID: "abc12"},
+		"TwitchLib/1.0",
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !banned {
+		t.Fatal("expected user agent to be banned via preset pattern")
+	}
+}
+
+func TestIsUserAgentBannedSkipsInvalidPatterns(t *testing.T) {
+	direct := &linkBannedUserAgentsStub{
+		patterns: []shortlinkslinkbannedusaragentsrepository.BannedUserAgent{
+			{Pattern: "(["},
+			{Pattern: "chatterino"},
+		},
+	}
+	service := newBanCheckService(direct, &linkPresetsStub{}, &presetPatternsStub{})
+
+	banned, err := service.IsUserAgentBanned(
+		context.Background(),
+		model.ShortenedUrl{ID: "link-pk"},
+		"Chatterino/2.5.3",
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !banned {
+		t.Fatal("expected invalid pattern to be skipped and valid one to match")
+	}
+}
+
+func TestIsUserAgentBannedEmptyUserAgent(t *testing.T) {
+	direct := &linkBannedUserAgentsStub{}
+	linkPresets := &linkPresetsStub{}
+	service := newBanCheckService(direct, linkPresets, &presetPatternsStub{})
+
+	banned, err := service.IsUserAgentBanned(
+		context.Background(),
+		model.ShortenedUrl{ID: "link-pk"},
+		"",
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if banned {
+		t.Fatal("expected empty user agent to never be banned")
+	}
+	if len(direct.getByLinkIDCalls) != 0 || len(linkPresets.getByLinkIDCalls) != 0 {
+		t.Fatal("expected no repository calls for empty user agent")
+	}
+}
+
+func TestIsUserAgentBannedWithoutLinkPrimaryKey(t *testing.T) {
+	direct := &linkBannedUserAgentsStub{}
+	linkPresets := &linkPresetsStub{}
+	service := newBanCheckService(direct, linkPresets, &presetPatternsStub{})
+
+	banned, err := service.IsUserAgentBanned(
+		context.Background(),
+		model.ShortenedUrl{ShortID: "abc12"},
+		"Chatterino/2.5.3",
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if banned {
+		t.Fatal("expected link without primary key to never be banned")
+	}
+	if len(direct.getByLinkIDCalls) != 0 || len(linkPresets.getByLinkIDCalls) != 0 {
+		t.Fatal("expected no repository calls without link primary key")
+	}
+}
+
+func TestCreateLinkBannedUserAgentRejectsInvalidPattern(t *testing.T) {
+	direct := &linkBannedUserAgentsStub{}
+	service := newBanCheckService(direct, &linkPresetsStub{}, &presetPatternsStub{})
+
+	_, err := service.CreateLinkBannedUserAgent(
+		context.Background(),
+		shortlinkslinkbannedusaragentsrepository.CreateInput{
+			LinkID:  "link-pk",
+			Pattern: "([",
+		},
+	)
+	if err == nil {
+		t.Fatal("expected invalid pattern to be rejected")
+	}
+	if direct.createCalls != 0 {
+		t.Fatalf("expected no repository calls, got %d", direct.createCalls)
+	}
+}

--- a/libs/repositories/shortened_urls/datasource/postgres/pgx.go
+++ b/libs/repositories/shortened_urls/datasource/postgres/pgx.go
@@ -34,6 +34,7 @@ var (
 	_             shortened_urls.Repository = (*Pgx)(nil)
 	sq                                      = squirrel.StatementBuilder.PlaceholderFormat(squirrel.Dollar)
 	selectColumns                           = []string{
+		"shortened_urls.id",
 		"shortened_urls.short_id",
 		"shortened_urls.created_at",
 		"shortened_urls.updated_at",
@@ -48,6 +49,7 @@ var (
 	}
 	selectColumnsStr = strings.Join(selectColumns, ", ")
 	selectColumnsCte = []string{
+		"updated.id",
 		"updated.short_id",
 		"updated.created_at",
 		"updated.updated_at",
@@ -62,6 +64,7 @@ var (
 	}
 	selectColumnsCteStr  = strings.Join(selectColumnsCte, ", ")
 	selectColumnsCreated = []string{
+		"created.id",
 		"created.short_id",
 		"created.created_at",
 		"created.updated_at",
@@ -202,7 +205,7 @@ func (c *Pgx) Update(
 	updateBuilder := sq.Update("shortened_urls").
 		Where(squirrel.Eq{"short_id": id}).
 		Set("updated_at", squirrel.Expr("NOW()")).
-		Suffix("RETURNING short_id, created_at, updated_at, url, created_by_user_id, views, user_ip, user_agent, domain_id, ignore_global_bans")
+		Suffix("RETURNING id, short_id, created_at, updated_at, url, created_by_user_id, views, user_ip, user_agent, domain_id, ignore_global_bans")
 
 	if domainID == nil {
 		updateBuilder = updateBuilder.Where("domain_id IS NULL")
@@ -327,7 +330,7 @@ func (c *Pgx) Create(ctx context.Context, input shortened_urls.CreateInput) (
 WITH created AS (
 	INSERT INTO shortened_urls (short_id, url, created_by_user_id, user_ip, user_agent, domain_id, ignore_global_bans)
 	VALUES (@short_id, @url, @created_by_user_id, @user_ip, @user_agent, @domain_id, @ignore_global_bans)
-	RETURNING short_id, created_at, updated_at, url, created_by_user_id, views, user_ip, user_agent, domain_id, ignore_global_bans
+	RETURNING id, short_id, created_at, updated_at, url, created_by_user_id, views, user_ip, user_agent, domain_id, ignore_global_bans
 )
 SELECT ` + selectColumnsCreatedStr + `
 FROM created

--- a/libs/repositories/shortened_urls/model/model.go
+++ b/libs/repositories/shortened_urls/model/model.go
@@ -6,6 +6,7 @@ import (
 )
 
 type ShortenedUrl struct {
+	ID               string
 	ShortID          string
 	CreatedAt        time.Time
 	UpdatedAt        time.Time

--- a/web/layers/url-shortener/components/url-shortener/banned-ua-dialog.vue
+++ b/web/layers/url-shortener/components/url-shortener/banned-ua-dialog.vue
@@ -347,7 +347,8 @@ function closeDialog() {
 							Add pattern
 						</Button>
 						<p class="text-xs text-[hsl(240,11%,55%)]">
-							Use a valid JavaScript regex. Matching is case-insensitive against the full
+							Use a valid regular expression (RE2 syntax, no lookaheads). Matching is
+							case-insensitive against the full
 							<span class="font-mono">User-Agent</span> header.
 						</p>
 					</div>

--- a/web/layers/url-shortener/components/url-shortener/banned-ua-presets-panel.vue
+++ b/web/layers/url-shortener/components/url-shortener/banned-ua-presets-panel.vue
@@ -445,7 +445,8 @@ async function handleDeletePattern(presetId: string, patternId: string) {
 									{{ patternErrors.get(preset.id) }}
 								</p>
 								<p class="text-xs text-[hsl(240,11%,55%)]">
-									Use a valid JavaScript regex. Matching is case-insensitive against the full
+									Use a valid regular expression (RE2 syntax, no lookaheads). Matching is
+									case-insensitive against the full
 									<span class="font-mono">User-Agent</span> header.
 								</p>
 							</div>


### PR DESCRIPTION
## Problem

Closes #1053

Two independent bugs made per-link banned User-Agent patterns (and presets) completely non-functional:

### 1. Foreign key violation on any write (`SQLSTATE 23503`)

`short_links_link_banned_user_agents.link_id` and `short_links_link_presets.link_id` reference `shortened_urls(id)` — the uuidv7 primary key. But every code path passed the **public short ID** from the URL path (`by-id/onlyfans`) or `link.ShortID`:

- `POST/GET/DELETE /v1/short-links/by-id/{linkId}/banned-user-agents`
- `POST/GET/DELETE /v1/short-links/by-id/{linkId}/presets`
- `IsUserAgentBanned` at redirect time
- MCP tools `list_banned_user_agents` / `ban_user_agent` / `unban_user_agent`

So every insert died on the FK constraint (the issue), and the redirect-time check queried rows keyed by an ID that could never exist — even a successfully applied preset would never match.

### 2. Case-sensitive matching despite UI promising case-insensitive

The UI says "Matching is case-insensitive against the full User-Agent header", but the backend compiled patterns with plain Go `regexp.Compile` — case-sensitive. A lowercase preset like `chatterino.+|ffzbot.+` never matched the real `Chatterino/2.x` header, so Chatterino kept rendering link previews.

## Fix

- `model.ShortenedUrl` now exposes the `id` PK; all shortened_urls pgx queries select/return it.
- All link-scoped handlers resolve the owned link once via `resolveOwnedShortLink` and use its primary key for `link_id`. Same for MCP tools via `ownedShortURL`.
- `IsUserAgentBanned` looks up patterns by link PK and compiles them through a single shared `compileBannedUAPattern` helper with the `(?i)` flag — validation (`CreatePresetPattern` / `CreateLinkBannedUserAgent`) and redirect-time matching now behave identically and case-insensitively.
- Frontend hint corrected: it claimed "JavaScript regex"; patterns are actually matched server-side with Go RE2 (documented, incl. no-lookahead note).

No data migration needed: the FK constraint made every historical insert fail, so both tables are empty in practice.

## Tests

Added `shortenedurls_test.go` covering:
- case-insensitive matching (`chatterino.+|ffzbot.+` vs `Chatterino/2.5.3`)
- lookups keyed by link primary key, not short ID
- preset-based matching, invalid patterns skipped, empty UA short-circuit, missing PK short-circuit
- pattern validation on create

`go test ./internal/delivery/mcp/ ./internal/delivery/http/... ./internal/services/shortenedurls/` — 211 passed.