### PR TITLE
feat: display message replies in chat overlay

### DIFF
--- a/apps/api-gql/internal/delivery/gql/mappers/chat_messages.go
+++ b/apps/api-gql/internal/delivery/gql/mappers/chat_messages.go
@@ -53,6 +53,21 @@ func ChatMessageToGQL(input entity.ChatMessage) gqlmodel.ChatMessage {
 		announceColor = lo.ToPtr(input.AnnounceColor)
 	}
 
+	var reply *gqlmodel.ChatMessageReply
+	if input.Reply != nil {
+		reply = &gqlmodel.ChatMessageReply{
+			ParentMessageID:   input.Reply.ParentMessageID,
+			ParentMessageBody: input.Reply.ParentMessageBody,
+			ParentUserID:      input.Reply.ParentUserID,
+			ParentUserName:    input.Reply.ParentUserName,
+			ParentUserLogin:   input.Reply.ParentUserLogin,
+			ThreadMessageID:   input.Reply.ThreadMessageID,
+			ThreadUserID:      input.Reply.ThreadUserID,
+			ThreadUserName:    input.Reply.ThreadUserName,
+			ThreadUserLogin:   input.Reply.ThreadUserLogin,
+		}
+	}
+
 	return gqlmodel.ChatMessage{
 		ID:              input.ID,
 		Platform:        input.Platform,
@@ -70,6 +85,7 @@ func ChatMessageToGQL(input entity.ChatMessage) gqlmodel.ChatMessage {
 		AnnounceColor:   announceColor,
 		Badges:          badges,
 		Fragments:       fragments,
+		Reply:           reply,
 	}
 }
 

--- a/apps/api-gql/internal/delivery/gql/schema/chat-messages.graphql
+++ b/apps/api-gql/internal/delivery/gql/schema/chat-messages.graphql
@@ -34,6 +34,19 @@ type ChatMessage {
 	announceColor: String
 	badges: [ChatMessageBadge!]!
 	fragments: [ChatMessageFragment!]!
+	reply: ChatMessageReply
+}
+
+type ChatMessageReply {
+	parentMessageId: String!
+	parentMessageBody: String!
+	parentUserId: String!
+	parentUserName: String!
+	parentUserLogin: String!
+	threadMessageId: String!
+	threadUserId: String!
+	threadUserName: String!
+	threadUserLogin: String!
 }
 
 type ChatMessageBadge {

--- a/apps/api-gql/internal/entity/chat_message.go
+++ b/apps/api-gql/internal/entity/chat_message.go
@@ -25,6 +25,19 @@ type ChatMessage struct {
 	AnnounceColor string                `json:"announceColor,omitempty"`
 	Badges        []ChatMessageBadge    `json:"badges,omitempty"`
 	Fragments     []ChatMessageFragment `json:"fragments,omitempty"`
+	Reply         *ChatMessageReply     `json:"reply,omitempty"`
+}
+
+type ChatMessageReply struct {
+	ParentMessageID   string `json:"parentMessageId,omitempty"`
+	ParentMessageBody string `json:"parentMessageBody,omitempty"`
+	ParentUserID      string `json:"parentUserId,omitempty"`
+	ParentUserName    string `json:"parentUserName,omitempty"`
+	ParentUserLogin   string `json:"parentUserLogin,omitempty"`
+	ThreadMessageID   string `json:"threadMessageId,omitempty"`
+	ThreadUserID      string `json:"threadUserId,omitempty"`
+	ThreadUserName    string `json:"threadUserName,omitempty"`
+	ThreadUserLogin   string `json:"threadUserLogin,omitempty"`
 }
 
 type ChatMessageBadge struct {

--- a/apps/api-gql/internal/services/chat_messages/chat_messages.go
+++ b/apps/api-gql/internal/services/chat_messages/chat_messages.go
@@ -127,6 +127,20 @@ func (c *Service) handleBusEvent(_ context.Context, data generic.ChatMessage) (
 			textBuilder.WriteString(data.Text)
 		}
 	}
+	var reply *entity.ChatMessageReply
+	if data.Reply != nil {
+		reply = &entity.ChatMessageReply{
+			ParentMessageID:   data.Reply.ParentMessageId,
+			ParentMessageBody: data.Reply.ParentMessageBody,
+			ParentUserID:      data.Reply.ParentUserId,
+			ParentUserName:    data.Reply.ParentUserName,
+			ParentUserLogin:   data.Reply.ParentUserLogin,
+			ThreadMessageID:   data.Reply.ThreadMessageId,
+			ThreadUserID:      data.Reply.ThreadUserId,
+			ThreadUserName:    data.Reply.ThreadUserName,
+			ThreadUserLogin:   data.Reply.ThreadUserLogin,
+		}
+	}
 	msg := entity.ChatMessage{
 		ID:              uuid.New(),
 		Platform:        data.Platform,
@@ -145,6 +159,7 @@ func (c *Service) handleBusEvent(_ context.Context, data generic.ChatMessage) (
 		AnnounceColor:   data.AnnounceColor,
 		Badges:          mapChatMessageBadges(data.Badges),
 		Fragments:       mapChatMessageFragments(data.Message),
+		Reply:           reply,
 	}
 
 	channelSubKey := chatMessagesSubscriptionKeyCreate(data.Platform, data.PlatformChannelID)

--- a/frontend/overlays/src/composables/chat/fragments-to-chunks.ts
+++ b/frontend/overlays/src/composables/chat/fragments-to-chunks.ts
@@ -13,6 +13,37 @@ export interface ChatEventFragment {
 	emoteUrl?: string | null
 }
 
+const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+
+/**
+ * Twitch prefixes reply messages with the parent mention ("@parentName ...").
+ * Strip that leading mention so only the actual reply text is displayed.
+ */
+export function stripReplyMention(
+	fragments: readonly ChatEventFragment[],
+	parentUserName: string,
+): ChatEventFragment[] {
+	const [first, ...rest] = fragments
+	if (!first) return [...fragments]
+
+	if (first.type === 'mention') {
+		const [second, ...others] = rest
+		if (second && second.type === 'text') {
+			const text = second.text.replace(/^\s+/, '')
+			return text ? [{ ...second, text }, ...others] : others
+		}
+		return rest
+	}
+
+	if (first.type !== 'text' || !parentUserName) return [...fragments]
+
+	const mentionRegexp = new RegExp(`^@${escapeRegExp(parentUserName)}\\s*`, 'i')
+	if (!mentionRegexp.test(first.text)) return [...fragments]
+
+	const text = first.text.replace(mentionRegexp, '')
+	return text ? [{ ...first, text }, ...rest] : rest
+}
+
 export function useFragmentsToChunks() {
 	const { emotes: thirdPartyEmotes } = useEmotes()
 

--- a/frontend/overlays/src/composables/chat/fragments-to-chunks.ts
+++ b/frontend/overlays/src/composables/chat/fragments-to-chunks.ts
@@ -26,22 +26,27 @@ export function stripReplyMention(
 	const [first, ...rest] = fragments
 	if (!first) return [...fragments]
 
+	let remaining: ChatEventFragment[]
+
 	if (first.type === 'mention') {
-		const [second, ...others] = rest
-		if (second && second.type === 'text') {
-			const text = second.text.replace(/^\s+/, '')
-			return text ? [{ ...second, text }, ...others] : others
-		}
-		return rest
+		remaining = rest
+	} else if (first.type === 'text' && parentUserName) {
+		const mentionRegexp = new RegExp(`^@${escapeRegExp(parentUserName)}(?=\\s|$)`, 'i')
+		if (!mentionRegexp.test(first.text)) return [...fragments]
+
+		const text = first.text.replace(mentionRegexp, '')
+		remaining = text ? [{ ...first, text }, ...rest] : rest
+	} else {
+		return [...fragments]
 	}
 
-	if (first.type !== 'text' || !parentUserName) return [...fragments]
+	const [next, ...others] = remaining
+	if (next && next.type === 'text') {
+		const text = next.text.replace(/^\s+/, '')
+		return text ? [{ ...next, text }, ...others] : others
+	}
 
-	const mentionRegexp = new RegExp(`^@${escapeRegExp(parentUserName)}\\s*`, 'i')
-	if (!mentionRegexp.test(first.text)) return [...fragments]
-
-	const text = first.text.replace(mentionRegexp, '')
-	return text ? [{ ...first, text }, ...rest] : rest
+	return remaining
 }
 
 export function useFragmentsToChunks() {

--- a/frontend/overlays/src/composables/chat/use-chat-overlay-socket.ts
+++ b/frontend/overlays/src/composables/chat/use-chat-overlay-socket.ts
@@ -102,15 +102,26 @@ export const useChatOverlaySocket = createGlobalState(() => {
 						versionId
 						text
 					}
-					fragments {
-						type
-						text
-						emoteId
-						emoteUrl
-					}
+				fragments {
+					type
+					text
+					emoteId
+					emoteUrl
+				}
+				reply {
+					parentMessageId
+					parentMessageBody
+					parentUserId
+					parentUserName
+					parentUserLogin
+					threadMessageId
+					threadUserId
+					threadUserName
+					threadUserLogin
 				}
 			}
-		`),
+		}
+	`),
 		variables: {
 			apiKey: route.params.apiKey as string,
 		},

--- a/frontend/overlays/src/composables/tmi/use-chat-tmi.ts
+++ b/frontend/overlays/src/composables/tmi/use-chat-tmi.ts
@@ -100,6 +100,13 @@ export function useChatTmi(options: Ref<ChatSettings>) {
 		}
 	}
 
+	function stripReplyMention(message: string, reply: Message['reply']): string {
+		if (!reply?.parentUserName) return message
+
+		const escaped = reply.parentUserName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+		return message.replace(new RegExp(`^@${escaped}\\s*`, 'i'), '')
+	}
+
 	async function destroy() {
 		if (!client) return
 
@@ -121,19 +128,22 @@ export function useChatTmi(options: Ref<ChatSettings>) {
 		})
 
 		client.on('message', (_channel, tags, message) => {
+			const reply = messageReply(tags)
+			const text = stripReplyMention(message, reply)
+
 			options.value.onMessage(createMessage({
 				id: tags.id,
 				type: 'message',
 				platform: 'twitch',
-				rawMessage: message,
-				chunks: messageChunks(message, tags),
+				rawMessage: text,
+				chunks: messageChunks(text, tags),
 				sender: tags.username,
 				senderId: tags['user-id']!,
 				senderColor: tags.color,
 				senderDisplayName: tags['display-name'],
 				badges: tags.badges as Record<string, string> | undefined,
 				isItalic: tags['message-type'] === 'action',
-				reply: messageReply(tags),
+				reply,
 			}))
 		})
 

--- a/frontend/overlays/src/composables/tmi/use-chat-tmi.ts
+++ b/frontend/overlays/src/composables/tmi/use-chat-tmi.ts
@@ -82,6 +82,24 @@ export function useChatTmi(options: Ref<ChatSettings>) {
 		})
 	}
 
+	function messageReply(tags: ChatUserstate): Message['reply'] {
+		const parentMessageId: string | undefined = tags['reply-parent-msg-id']
+		if (!parentMessageId) return undefined
+
+		const parentMessageBody: string = tags['reply-parent-msg-body'] ?? ''
+		const parentUserId: string = tags['reply-parent-user-id'] ?? ''
+		const parentUserName: string = tags['reply-parent-display-name'] ?? ''
+		const parentUserLogin: string = tags['reply-parent-user-login'] ?? ''
+
+		return {
+			parentMessageId,
+			parentMessageBody,
+			parentUserId,
+			parentUserName,
+			parentUserLogin,
+		}
+	}
+
 	async function destroy() {
 		if (!client) return
 
@@ -115,6 +133,7 @@ export function useChatTmi(options: Ref<ChatSettings>) {
 				senderDisplayName: tags['display-name'],
 				badges: tags.badges as Record<string, string> | undefined,
 				isItalic: tags['message-type'] === 'action',
+				reply: messageReply(tags),
 			}))
 		})
 

--- a/frontend/overlays/src/pages/overlays/chat.vue
+++ b/frontend/overlays/src/pages/overlays/chat.vue
@@ -4,7 +4,7 @@ import type { Message, MessagePlatform } from '@twir/frontend-chat'
 import { ChatBox } from '@twir/frontend-chat'
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 
-import { useFragmentsToChunks } from '@/composables/chat/fragments-to-chunks.js'
+import { stripReplyMention, useFragmentsToChunks } from '@/composables/chat/fragments-to-chunks.js'
 import { useChatOverlaySocket } from '@/composables/chat/use-chat-overlay-socket.js'
 import { knownBots } from '@/composables/tmi/use-chat-tmi.js'
 import { useThirdPartyEmotes } from '@/composables/tmi/use-third-party-emotes.js'
@@ -102,11 +102,23 @@ watch(chatMessages, (v) => {
 		}
 	}
 
+	const reply = event.reply
+		? {
+				parentMessageId: event.reply.parentMessageId,
+				parentMessageBody: event.reply.parentMessageBody,
+				parentUserId: event.reply.parentUserId,
+				parentUserName: event.reply.parentUserName,
+				parentUserLogin: event.reply.parentUserLogin,
+			}
+		: undefined
+
 	pushMessage({
 		id: event.messageId ?? event.id,
 		type: 'message',
 		platform,
-		chunks: fragmentsToChunks(event.fragments),
+		chunks: fragmentsToChunks(
+			reply ? stripReplyMention(event.fragments, reply.parentUserName) : event.fragments,
+		),
 		sender: event.userName,
 		senderColor: event.userColor || undefined,
 		senderDisplayName: event.userDisplayName,
@@ -115,15 +127,7 @@ watch(chatMessages, (v) => {
 		isItalic: false,
 		isAnnounce: event.messageType === 'announcement',
 		announceColor: event.announceColor ?? undefined,
-		reply: event.reply
-			? {
-					parentMessageId: event.reply.parentMessageId,
-					parentMessageBody: event.reply.parentMessageBody,
-					parentUserId: event.reply.parentUserId,
-					parentUserName: event.reply.parentUserName,
-					parentUserLogin: event.reply.parentUserLogin,
-				}
-			: undefined,
+		reply,
 	})
 })
 

--- a/frontend/overlays/src/pages/overlays/chat.vue
+++ b/frontend/overlays/src/pages/overlays/chat.vue
@@ -115,6 +115,15 @@ watch(chatMessages, (v) => {
 		isItalic: false,
 		isAnnounce: event.messageType === 'announcement',
 		announceColor: event.announceColor ?? undefined,
+		reply: event.reply
+			? {
+					parentMessageId: event.reply.parentMessageId,
+					parentMessageBody: event.reply.parentMessageBody,
+					parentUserId: event.reply.parentUserId,
+					parentUserName: event.reply.parentUserName,
+					parentUserLogin: event.reply.parentUserLogin,
+				}
+			: undefined,
 	})
 })
 

--- a/libs/frontend-chat/src/components/message-reply.vue
+++ b/libs/frontend-chat/src/components/message-reply.vue
@@ -3,7 +3,7 @@ import type { MessageReply } from '../types.js'
 
 defineProps<{
 	reply: MessageReply
-	variant: 'compact' | 'card'
+	variant: 'compact' | 'card' | 'inline'
 }>()
 </script>
 
@@ -28,7 +28,7 @@ defineProps<{
 		</span>
 	</div>
 
-	<div v-else class="reply reply-card">
+	<div v-else-if="variant === 'card'" class="reply reply-card">
 		<div class="reply-card-header">
 			<svg
 				xmlns="http://www.w3.org/2000/svg"
@@ -49,6 +49,25 @@ defineProps<{
 		</div>
 		<div class="reply-card-text">{{ reply.parentMessageBody }}</div>
 	</div>
+
+	<span v-else class="reply reply-inline">
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			stroke-width="2"
+			stroke-linecap="round"
+			stroke-linejoin="round"
+			class="reply-icon"
+		>
+			<path d="M9 14 4 9l5-5" />
+			<path d="M20 20v-7a4 4 0 0 0-4-4H4" />
+		</svg>
+		<span class="reply-inline-text">
+			<span class="reply-name">@{{ reply.parentUserName }}</span>: {{ reply.parentMessageBody }}
+		</span>
+	</span>
 </template>
 
 <style scoped>
@@ -125,5 +144,25 @@ defineProps<{
 	-webkit-box-orient: vertical;
 	overflow: hidden;
 	word-break: break-word;
+}
+
+/* Inline variant (horizontal layouts): prefix inside the message line */
+.reply-inline {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.25em;
+	max-width: 15em;
+	margin-right: 0.35em;
+	font-size: 0.7em;
+	line-height: 1.4;
+	color: rgba(255, 255, 255, 0.55);
+	white-space: nowrap;
+	overflow: hidden;
+	vertical-align: middle;
+}
+
+.reply-inline-text {
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 </style>

--- a/libs/frontend-chat/src/components/message-reply.vue
+++ b/libs/frontend-chat/src/components/message-reply.vue
@@ -1,0 +1,129 @@
+<script setup lang="ts">
+import type { MessageReply } from '../types.js'
+
+defineProps<{
+	reply: MessageReply
+	variant: 'compact' | 'card'
+}>()
+</script>
+
+<template>
+	<div v-if="variant === 'compact'" class="reply reply-compact">
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			stroke-width="2"
+			stroke-linecap="round"
+			stroke-linejoin="round"
+			class="reply-icon"
+		>
+			<path d="M9 14 4 9l5-5" />
+			<path d="M20 20v-7a4 4 0 0 0-4-4H4" />
+		</svg>
+		<span class="reply-line">
+			Replying to <span class="reply-name">@{{ reply.parentUserName }}</span>:
+			{{ reply.parentMessageBody }}
+		</span>
+	</div>
+
+	<div v-else class="reply reply-card">
+		<div class="reply-card-header">
+			<svg
+				xmlns="http://www.w3.org/2000/svg"
+				viewBox="0 0 24 24"
+				fill="none"
+				stroke="currentColor"
+				stroke-width="2"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				class="reply-icon"
+			>
+				<path d="M9 14 4 9l5-5" />
+				<path d="M20 20v-7a4 4 0 0 0-4-4H4" />
+			</svg>
+			<span class="reply-card-title">
+				Replying to <span class="reply-name">@{{ reply.parentUserName }}</span>
+			</span>
+		</div>
+		<div class="reply-card-text">{{ reply.parentMessageBody }}</div>
+	</div>
+</template>
+
+<style scoped>
+.reply-icon {
+	display: inline-block;
+	height: 1em;
+	width: 1em;
+	flex: none;
+	vertical-align: -0.15em;
+}
+
+.reply-name {
+	color: rgba(255, 255, 255, 0.85);
+	font-weight: 600;
+}
+
+/* Compact variant (clean preset): single muted truncated line */
+.reply-compact {
+	display: block;
+	width: 100%;
+	max-width: 100%;
+	margin-bottom: 0.15em;
+	font-size: 0.7em;
+	line-height: 1.4;
+	color: rgba(255, 255, 255, 0.55);
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	box-sizing: border-box;
+}
+
+.reply-compact .reply-icon {
+	margin-right: 0.3em;
+}
+
+/* Card variant (boxed preset): quote-style block inside the box */
+.reply-card {
+	display: flex;
+	flex-direction: column;
+	gap: 0.1em;
+	width: 100%;
+	max-width: 100%;
+	margin-bottom: 0.2em;
+	padding: 0.35em 0.55em;
+	font-size: 0.8em;
+	line-height: 1.35;
+	background-color: rgba(255, 255, 255, 0.06);
+	border-left: 3px solid rgba(255, 255, 255, 0.25);
+	border-radius: 6px;
+	white-space: normal;
+	box-sizing: border-box;
+}
+
+.reply-card-header {
+	display: flex;
+	align-items: center;
+	gap: 0.3em;
+	font-size: 0.9em;
+	color: rgba(255, 255, 255, 0.7);
+	white-space: nowrap;
+	overflow: hidden;
+}
+
+.reply-card-title {
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.reply-card-text {
+	color: rgba(255, 255, 255, 0.6);
+	display: -webkit-box;
+	-webkit-line-clamp: 2;
+	line-clamp: 2;
+	-webkit-box-orient: vertical;
+	overflow: hidden;
+	word-break: break-word;
+}
+</style>

--- a/libs/frontend-chat/src/styles/boxed/message-horizontal.vue
+++ b/libs/frontend-chat/src/styles/boxed/message-horizontal.vue
@@ -1,6 +1,7 @@
 <script lang="ts" setup>
 import MessageBadges from '../../components/message-badges.vue'
 import MessageContent from '../../components/message-content.vue'
+import MessageReply from '../../components/message-reply.vue'
 import { normalizeDisplayName } from '../../helpers.js'
 
 import type { MessageComponentProps } from '../../types.js'
@@ -15,6 +16,7 @@ defineProps<MessageComponentProps>()
 			border: msg.isAnnounce && settings.showAnnounceBadge ? '2px solid #9146ff' : undefined,
 		}"
 	>
+		<MessageReply v-if="msg.reply" :reply="msg.reply" variant="card" class="reply" />
 		<div class="profile">
 			<div v-if="msg.sender" class="username">
 				{{ normalizeDisplayName(msg.sender!, msg.senderDisplayName!) }}
@@ -48,6 +50,10 @@ defineProps<MessageComponentProps>()
 	display: flex;
 	justify-content: space-between;
 	gap: 4px;
+}
+
+.reply {
+	max-width: 24em;
 }
 
 .username {

--- a/libs/frontend-chat/src/styles/boxed/message-vertical.vue
+++ b/libs/frontend-chat/src/styles/boxed/message-vertical.vue
@@ -1,6 +1,7 @@
 <script lang="ts" setup>
 import MessageBadges from '../../components/message-badges.vue'
 import MessageContent from '../../components/message-content.vue'
+import MessageReply from '../../components/message-reply.vue'
 import { normalizeDisplayName } from '../../helpers.js'
 
 import type { MessageComponentProps } from '../../types.js'
@@ -15,6 +16,7 @@ defineProps<MessageComponentProps>()
 			border: msg.isAnnounce && settings.showAnnounceBadge ? '2px solid #9146ff' : undefined,
 		}"
 	>
+		<MessageReply v-if="msg.reply" :reply="msg.reply" variant="card" />
 		<div class="profile">
 			<div v-if="msg.sender" class="username">
 				{{ normalizeDisplayName(msg.sender!, msg.senderDisplayName!) }}

--- a/libs/frontend-chat/src/styles/clean/message-horizontal.vue
+++ b/libs/frontend-chat/src/styles/clean/message-horizontal.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import MessageBadges from '../../components/message-badges.vue'
 import MessageContent from '../../components/message-content.vue'
+import MessageReply from '../../components/message-reply.vue'
 import { normalizeDisplayName } from '../../helpers'
 
 import type { MessageComponentProps } from '../../types'
@@ -10,30 +11,43 @@ defineProps<MessageComponentProps>()
 
 <template>
 	<div class="message">
-		<div class="profile">
-			<MessageBadges :msg="msg" :settings="settings" />
-			<div v-if="msg.sender" class="username">
-				{{ normalizeDisplayName(msg.sender!, msg.senderDisplayName!) }}
+		<MessageReply v-if="msg.reply" :reply="msg.reply" variant="compact" class="reply" />
+		<div class="message-line">
+			<div class="profile">
+				<MessageBadges :msg="msg" :settings="settings" />
+				<div v-if="msg.sender" class="username">
+					{{ normalizeDisplayName(msg.sender!, msg.senderDisplayName!) }}
+				</div>
+				<span v-if="msg.sender">
+					{{ msg.isItalic ? '' : ':' }}
+				</span>
 			</div>
-			<span v-if="msg.sender">
-				{{ msg.isItalic ? '' : ':' }}
-			</span>
+			<MessageContent
+				:chunks="msg.chunks"
+				:is-italic="msg.isItalic"
+				:text-shadow-color="settings.textShadowColor"
+				:text-shadow-size="settings.textShadowSize"
+				:user-color="userColor"
+			/>
 		</div>
-		<MessageContent
-			:chunks="msg.chunks"
-			:is-italic="msg.isItalic"
-			:text-shadow-color="settings.textShadowColor"
-			:text-shadow-size="settings.textShadowSize"
-			:user-color="userColor"
-		/>
 	</div>
 </template>
 
 <style scoped>
 .message {
 	display: inline-flex;
-	align-items: center;
+	flex-direction: column;
+	justify-content: center;
 	white-space: nowrap;
+}
+
+.message-line {
+	display: inline-flex;
+	align-items: center;
+}
+
+.reply {
+	max-width: 30em;
 }
 
 .profile {

--- a/libs/frontend-chat/src/styles/clean/message-horizontal.vue
+++ b/libs/frontend-chat/src/styles/clean/message-horizontal.vue
@@ -11,43 +11,31 @@ defineProps<MessageComponentProps>()
 
 <template>
 	<div class="message">
-		<MessageReply v-if="msg.reply" :reply="msg.reply" variant="compact" class="reply" />
-		<div class="message-line">
-			<div class="profile">
-				<MessageBadges :msg="msg" :settings="settings" />
-				<div v-if="msg.sender" class="username">
-					{{ normalizeDisplayName(msg.sender!, msg.senderDisplayName!) }}
-				</div>
-				<span v-if="msg.sender">
-					{{ msg.isItalic ? '' : ':' }}
-				</span>
+		<MessageReply v-if="msg.reply" :reply="msg.reply" variant="inline" />
+		<div class="profile">
+			<MessageBadges :msg="msg" :settings="settings" />
+			<div v-if="msg.sender" class="username">
+				{{ normalizeDisplayName(msg.sender!, msg.senderDisplayName!) }}
 			</div>
-			<MessageContent
-				:chunks="msg.chunks"
-				:is-italic="msg.isItalic"
-				:text-shadow-color="settings.textShadowColor"
-				:text-shadow-size="settings.textShadowSize"
-				:user-color="userColor"
-			/>
+			<span v-if="msg.sender">
+				{{ msg.isItalic ? '' : ':' }}
+			</span>
 		</div>
+		<MessageContent
+			:chunks="msg.chunks"
+			:is-italic="msg.isItalic"
+			:text-shadow-color="settings.textShadowColor"
+			:text-shadow-size="settings.textShadowSize"
+			:user-color="userColor"
+		/>
 	</div>
 </template>
 
 <style scoped>
 .message {
 	display: inline-flex;
-	flex-direction: column;
-	justify-content: center;
-	white-space: nowrap;
-}
-
-.message-line {
-	display: inline-flex;
 	align-items: center;
-}
-
-.reply {
-	max-width: 30em;
+	white-space: nowrap;
 }
 
 .profile {

--- a/libs/frontend-chat/src/styles/clean/message-vertical.vue
+++ b/libs/frontend-chat/src/styles/clean/message-vertical.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import MessageBadges from '../../components/message-badges.vue'
 import MessageContent from '../../components/message-content.vue'
+import MessageReply from '../../components/message-reply.vue'
 import { normalizeDisplayName } from '../../helpers'
 
 import type { MessageComponentProps } from '../../types'
@@ -10,6 +11,7 @@ defineProps<MessageComponentProps>()
 
 <template>
 	<div class="message">
+		<MessageReply v-if="msg.reply" :reply="msg.reply" variant="compact" />
 		<div class="profile">
 			<MessageBadges :msg="msg" :settings="settings" />
 			<div v-if="msg.sender" class="username">

--- a/libs/frontend-chat/src/types.ts
+++ b/libs/frontend-chat/src/types.ts
@@ -52,6 +52,14 @@ export interface KickBadge {
 	text: string
 }
 
+export interface MessageReply {
+	parentMessageId: string
+	parentMessageBody: string
+	parentUserId: string
+	parentUserName: string
+	parentUserLogin: string
+}
+
 export interface Message {
 	internalId: string
 	id?: string
@@ -67,6 +75,7 @@ export interface Message {
 	createdAt: Date
 	announceColor?: string
 	isAnnounce: boolean
+	reply?: MessageReply
 }
 
 export interface Settings {

--- a/web/layers/dashboard/pages/dashboard/overlays/chat/components/Form.vue
+++ b/web/layers/dashboard/pages/dashboard/overlays/chat/components/Form.vue
@@ -74,6 +74,9 @@ watch(
 )
 
 // Generate mock messages
+let mockTick = 0
+const recentMockMessages: Array<{ sender: string; senderDisplayName: string; body: string }> = []
+
 useIntervalFn(() => {
 	if (!formValue.value) return
 
@@ -94,8 +97,15 @@ useIntervalFn(() => {
 
 	const isKickMessage = messagesMock.value.length % 2 === 1
 
+	mockTick++
+	const replyParent =
+		mockTick % 3 === 0 ? faker.randomArrayItem(recentMockMessages) : undefined
+
+	const sender = faker.firstName()!
+	const senderDisplayName = faker.firstName()!
+
 	messagesMock.value.push({
-		sender: faker.firstName(),
+		sender,
 		chunks: [{ type: 'text', value: randomWord! }],
 		createdAt: new Date(),
 		internalId,
@@ -115,8 +125,22 @@ useIntervalFn(() => {
 				]
 			: undefined,
 		id: crypto.randomUUID(),
-		senderDisplayName: faker.firstName(),
+		senderDisplayName,
+		reply: replyParent
+			? {
+					parentMessageId: crypto.randomUUID(),
+					parentMessageBody: replyParent.body,
+					parentUserId: crypto.randomUUID(),
+					parentUserName: replyParent.senderDisplayName,
+					parentUserLogin: replyParent.sender,
+				}
+			: undefined,
 	})
+
+	recentMockMessages.push({ sender, senderDisplayName, body: randomWord! })
+	if (recentMockMessages.length > 10) {
+		recentMockMessages.shift()
+	}
 
 	if (formValue.value.messageHideTimeout !== 0) {
 		setTimeout(() => {


### PR DESCRIPTION
## What

Adds Twitch-style reply rendering to the chat overlay, in both presets, plus reply examples in the dashboard preview.

Twitch reply metadata (`reply-parent-*`) was already mapped from EventSub into the bus `generic.ChatMessage`, but was dropped in api-gql. This PR plumbs it through to the `chatMessagesByApiKey` subscription and renders it.

## Changes

**Backend (api-gql)**
- `entity.ChatMessage` gains `Reply *ChatMessageReply` (parent + thread fields)
- `chat_messages` service copies bus reply data into the entity
- GraphQL: `ChatMessage.reply` + `ChatMessageReply` type, mapped in the gql mapper

**Frontend**
- `@twir/frontend-chat`: `Message.reply` + shared `message-reply.vue` component
  - **clean (compact)** preset: muted single truncated line above the message — `↩ Replying to @Name: parent text…`, like Twitch
  - **boxed** preset: quote-style card with left accent border, header + parent body clamped to 2 lines
  - wired into all 4 renderers (clean/boxed × vertical/horizontal)
- overlays: request reply fields in the subscription, map into `Message`, parse `reply-parent-*` tags in the legacy tmi.js path
- dashboard chat overlay preview: every 3rd mock message is a reply to a recent mock message, so both presets show the new rendering

## Verification

- `go build ./apps/api-gql/...` ✅
- `bun run build` in frontend/overlays (codegen + vue-tsc + vite build) ✅
- `vue-tsc` in libs/frontend-chat ✅
- oxlint on touched files ✅
- Visual QA via a temporary vite harness rendering ChatBox in all 4 preset/direction combos (harness removed afterwards)